### PR TITLE
Sharing interface v3

### DIFF
--- a/app/src/main/java/com/oracle/visualize/domain/models/NavRoutes.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/NavRoutes.kt
@@ -3,11 +3,8 @@ package com.oracle.visualize.domain.models
 sealed class NavRoutes(val route: String) {
     object Feed : NavRoutes("feed")
     object Notifications : NavRoutes("notifications")
-
     object Profile : NavRoutes("profile")
-
     object Teams : NavRoutes("teams")
-
     object Create : NavRoutes("create")
-
+    object Share : NavRoutes("share")
 }

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareAndPostState.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareAndPostState.kt
@@ -1,0 +1,10 @@
+package com.oracle.visualize.domain.models
+
+data class ShareAndPostState(
+    val emailQuery: String = "",
+    val selectedUsers: List<ShareUser> = emptyList(),
+    val suggestedUsers: List<ShareUser> = emptyList(),
+    val myTeams: List<ShareTeam> = emptyList(),
+    val teamsImIn: List<ShareTeam> = emptyList(),
+    val showUnsavedChangesDialog: Boolean = false
+)

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
@@ -1,0 +1,9 @@
+package com.oracle.visualize.domain.models
+
+data class ShareTeam(
+    val id: String,
+    val name: String,
+    val memberCount: Int,
+    val members: List<ShareUser> = emptyList(),
+    val isSelected: Boolean = false
+)

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareUser.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareUser.kt
@@ -1,0 +1,9 @@
+package com.oracle.visualize.domain.models
+
+data class ShareUser(
+    val id: String,
+    val name: String,
+    val email: String,
+    val avatarInitials: String,
+    val avatarColor: Long = 0xFFE8A87C
+)

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.oracle.visualize.domain.models.NavRoutes
@@ -17,11 +19,17 @@ import com.oracle.visualize.presentation.screens.ShareScreen.ShareAndPostScreen
 import com.oracle.visualize.ui.theme.ScreenBackground
 
 @Composable
-fun MainScreen(
-    viewModel: MainViewModel = viewModel()
-) {
+fun MainScreen(viewModel: MainViewModel = viewModel()) {
     val currentRoute by viewModel.currentRoute.collectAsStateWithLifecycle()
     val selectedIndex by viewModel.selectedIndex.collectAsStateWithLifecycle()
+
+    // Share screen ocupa pantalla completa, sin navbar
+    if (currentRoute == NavRoutes.Share.route) {
+        ShareAndPostScreen(
+            onNavigateBack = { viewModel.onNavItemSelected(2) }
+        )
+        return
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -37,7 +45,7 @@ fun MainScreen(
         ContentScreen(
             modifier = Modifier.padding(innerPadding),
             currentRoute = currentRoute,
-            onNavigateBack = { viewModel.onNavItemSelected(2) } // Back to Feed
+            onNavigateBack = { viewModel.onNavItemSelected(2) }
         )
     }
 }
@@ -46,13 +54,16 @@ fun MainScreen(
 fun ContentScreen(
     modifier: Modifier = Modifier,
     currentRoute: String,
-    onNavigateBack: () -> Unit = {}
+    onNavigateBack: () -> Unit = {},
+    bottomPadding: Dp = 0.dp
 ) {
     when (currentRoute) {
         NavRoutes.Feed.route -> FeedPage(modifier = modifier)
         NavRoutes.Notifications.route -> NotificationPage(modifier = modifier)
         NavRoutes.Create.route -> CreatePage(modifier = modifier)
-        NavRoutes.Share.route -> ShareAndPostScreen(onNavigateBack = onNavigateBack)
-        // Add other routes as they are implemented
+        NavRoutes.Share.route -> ShareAndPostScreen(
+            onNavigateBack = onNavigateBack,
+            bottomPadding =  bottomPadding
+        )
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
@@ -8,18 +8,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.oracle.visualize.presentation.components.BottomNavBar
 import com.oracle.visualize.domain.models.NavRoutes
+import com.oracle.visualize.presentation.components.BottomNavBar
+import com.oracle.visualize.presentation.screens.CreateScreen.CreatePage
 import com.oracle.visualize.presentation.screens.FeedScreen.FeedPage
 import com.oracle.visualize.presentation.screens.NotificationScreen.NotificationPage
-import com.oracle.visualize.presentation.screens.CreateScreen.CreatePage
+import com.oracle.visualize.presentation.screens.ShareScreen.ShareAndPostScreen
 import com.oracle.visualize.ui.theme.ScreenBackground
 
 @Composable
 fun MainScreen(
     viewModel: MainViewModel = viewModel()
 ) {
-    //We obtain the state from View
     val currentRoute by viewModel.currentRoute.collectAsStateWithLifecycle()
     val selectedIndex by viewModel.selectedIndex.collectAsStateWithLifecycle()
 
@@ -29,31 +29,30 @@ fun MainScreen(
             BottomNavBar(
                 navItems = viewModel.navItems,
                 selectedIndex = selectedIndex,
-                onItemSelected = viewModel::onNavItemSelected //Update the state
-
+                onItemSelected = viewModel::onNavItemSelected
             )
         },
         containerColor = ScreenBackground
     ) { innerPadding ->
         ContentScreen(
             modifier = Modifier.padding(innerPadding),
-            currentRoute = currentRoute //Update the screen type
+            currentRoute = currentRoute,
+            onNavigateBack = { viewModel.onNavItemSelected(2) } // Back to Feed
         )
     }
 }
 
-
-
-
 @Composable
 fun ContentScreen(
     modifier: Modifier = Modifier,
-    currentRoute: String
+    currentRoute: String,
+    onNavigateBack: () -> Unit = {}
 ) {
     when (currentRoute) {
         NavRoutes.Feed.route -> FeedPage(modifier = modifier)
         NavRoutes.Notifications.route -> NotificationPage(modifier = modifier)
         NavRoutes.Create.route -> CreatePage(modifier = modifier)
+        NavRoutes.Share.route -> ShareAndPostScreen(onNavigateBack = onNavigateBack)
         // Add other routes as they are implemented
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
 class MainViewModel : ViewModel() {
 
     //State
-    private val route = MutableStateFlow(NavRoutes.Feed.route)
+    private val route = MutableStateFlow(NavRoutes.Share.route)
     private val index = MutableStateFlow(2)
 
 

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
@@ -1,0 +1,357 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsTopHeight
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.oracle.visualize.domain.models.ShareAndPostState
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.presentation.screens.ShareScreen.components.SelectedUserRow
+import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRow
+import com.oracle.visualize.presentation.screens.ShareScreen.components.UnsavedChangesDialog
+import com.oracle.visualize.ui.theme.OrangeButton
+import com.oracle.visualize.ui.theme.TealPrimary
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+import com.oracle.visualize.ui.theme.TopBarColor
+
+private val SearchBarBg = Color(0xFFF5F5F5)
+private val SearchIconColor = Color(0xFF7FA9A9)
+
+@Composable
+fun ShareAndPostScreen(
+    viewModel: ShareAndPostViewModel = viewModel(),
+    onNavigateBack: () -> Unit = {}
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    ShareAndPostContent(
+        state = state,
+        onEmailQueryChange = viewModel::onEmailQueryChange,
+        onAddUserByEmail = viewModel::onAddUserByEmail,
+        onRemoveUser = viewModel::onRemoveUser,
+        onToggleTeam = viewModel::onToggleTeam,
+        onConfirmShare = viewModel::onConfirmShare,
+        onBackPressed = {
+            val hadSelections = state.selectedUsers.isNotEmpty() ||
+                    state.myTeams.any { it.isSelected } ||
+                    state.teamsImIn.any { it.isSelected }
+            if (hadSelections) viewModel.onBackPressed() else onNavigateBack()
+        },
+        onDismissUnsavedChanges = viewModel::onDismissUnsavedChanges,
+        onConfirmLeave = { viewModel.onConfirmLeave(); onNavigateBack() }
+    )
+}
+
+@Composable
+fun ShareAndPostContent(
+    state: ShareAndPostState,
+    onEmailQueryChange: (String) -> Unit,
+    onAddUserByEmail: (String) -> Unit,
+    onRemoveUser: (ShareUser) -> Unit,
+    onToggleTeam: (String, Boolean) -> Unit,
+    onConfirmShare: () -> Unit,
+    onBackPressed: () -> Unit,
+    onDismissUnsavedChanges: () -> Unit,
+    onConfirmLeave: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+
+            ShareTopBar(onBackPressed = onBackPressed)
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+            ) {
+                Spacer(modifier = Modifier.height(16.dp))
+                ShareSearchBar(
+                    query = state.emailQuery,
+                    onQueryChange = onEmailQueryChange
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                ShareUserList(
+                    state = state,
+                    onRemoveUser = onRemoveUser
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                ShareTeamSection(
+                    title = "My Teams",
+                    teams = state.myTeams,
+                    emptyMessage = "You haven't created any teams yet.",
+                    onToggleTeam = { id -> onToggleTeam(id, true) }
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                ShareTeamSection(
+                    title = "Teams I'm In",
+                    teams = state.teamsImIn,
+                    emptyMessage = "You're not part of any teams yet.",
+                    onToggleTeam = { id -> onToggleTeam(id, false) }
+                )
+                Spacer(modifier = Modifier.height(80.dp))
+            }
+
+            ShareBottomBar(onConfirmShare = onConfirmShare)
+        }
+
+        if (state.showUnsavedChangesDialog) {
+            UnsavedChangesDialog(
+                onDismiss = onDismissUnsavedChanges,
+                onConfirmLeave = onConfirmLeave
+            )
+        }
+    }
+}
+
+// ─── Top bar ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareTopBar(onBackPressed: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(80.dp)
+            .background(TopBarColor)
+    ) {
+        Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(100.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                IconButton(onClick = onBackPressed, modifier = Modifier.size(40.dp)) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = Color(0xFF1D1B20),
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = "Share and post",
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Normal,
+                color = Color(0xFF1D1B20),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .wrapContentHeight()
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+// ─── Search bar ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .shadow(1.dp, RoundedCornerShape(28.dp))
+            .background(SearchBarBg, RoundedCornerShape(28.dp))
+            .padding(horizontal = 4.dp)
+    ) {
+        Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = SearchIconColor,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+        TextField(
+            value = query,
+            onValueChange = onQueryChange,
+            placeholder = {
+                Text("Enter email", color = TextGray, fontSize = 14.sp)
+            },
+            singleLine = true,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                cursorColor = TealPrimary
+            ),
+            modifier = Modifier.weight(1f),
+            textStyle = LocalTextStyle.current.copy(fontSize = 16.sp)
+        )
+    }
+}
+
+// ─── User list ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareUserList(
+    state: ShareAndPostState,
+    onRemoveUser: (ShareUser) -> Unit
+) {
+    val displayUsers = if (state.selectedUsers.isNotEmpty()) state.selectedUsers
+    else state.suggestedUsers
+
+    if (displayUsers.isEmpty()) return
+
+    val visibleUsers = remember { mutableStateListOf(*displayUsers.toTypedArray()) }
+    LaunchedEffect(displayUsers) {
+        visibleUsers.clear()
+        visibleUsers.addAll(displayUsers)
+    }
+
+    visibleUsers.forEach { user ->
+        key(user.id) {
+            AnimatedVisibility(
+                visible = user in displayUsers,
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                Column {
+                    SelectedUserRow(user = user, onRemove = { onRemoveUser(user) })
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+        }
+    }
+}
+
+// ─── Team section ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareTeamSection(
+    title: String,
+    teams: List<com.oracle.visualize.domain.models.ShareTeam>,
+    emptyMessage: String,
+    onToggleTeam: (String) -> Unit
+) {
+    Text(
+        text = title,
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Bold,
+        color = TextDark,
+        modifier = Modifier.padding(bottom = 10.dp)
+    )
+    if (teams.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = emptyMessage, fontSize = 13.sp, color = TextGray)
+        }
+    } else {
+        teams.forEach { team ->
+            TeamRow(team = team, onToggle = { onToggleTeam(team.id) })
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+// ─── Bottom bar ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareBottomBar(onConfirmShare: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(88.dp)
+            .background(TopBarColor)
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Button(
+            onClick = onConfirmShare,
+            shape = RoundedCornerShape(100.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = OrangeButton,
+                contentColor = Color.White
+            ),
+            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+            modifier = Modifier
+                .width(184.dp)
+                .height(56.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Send,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Confirm",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.15.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
@@ -14,7 +14,11 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
@@ -48,14 +52,18 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.oracle.visualize.domain.models.ShareAndPostState
+import com.oracle.visualize.domain.models.ShareTeam
 import com.oracle.visualize.domain.models.ShareUser
 import com.oracle.visualize.presentation.screens.ShareScreen.components.SelectedUserRow
 import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRow
+import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRowPosition
 import com.oracle.visualize.presentation.screens.ShareScreen.components.UnsavedChangesDialog
 import com.oracle.visualize.ui.theme.OrangeButton
 import com.oracle.visualize.ui.theme.TealPrimary
@@ -63,13 +71,16 @@ import com.oracle.visualize.ui.theme.TextDark
 import com.oracle.visualize.ui.theme.TextGray
 import com.oracle.visualize.ui.theme.TopBarColor
 
-private val SearchBarBg = Color(0xFFF5F5F5)
+private val SearchBarBg   = Color(0xFFF5F4F2)
 private val SearchIconColor = Color(0xFF7FA9A9)
+
+
 
 @Composable
 fun ShareAndPostScreen(
     viewModel: ShareAndPostViewModel = viewModel(),
-    onNavigateBack: () -> Unit = {}
+    onNavigateBack: () -> Unit = {},
+    bottomPadding: Dp = 0.dp
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -87,9 +98,11 @@ fun ShareAndPostScreen(
             if (hadSelections) viewModel.onBackPressed() else onNavigateBack()
         },
         onDismissUnsavedChanges = viewModel::onDismissUnsavedChanges,
-        onConfirmLeave = { viewModel.onConfirmLeave(); onNavigateBack() }
+        onConfirmLeave = { viewModel.onConfirmLeave(); onNavigateBack() },
+        bottomPadding = bottomPadding
     )
 }
+
 
 @Composable
 fun ShareAndPostContent(
@@ -101,12 +114,13 @@ fun ShareAndPostContent(
     onConfirmShare: () -> Unit,
     onBackPressed: () -> Unit,
     onDismissUnsavedChanges: () -> Unit,
-    onConfirmLeave: () -> Unit
+    onConfirmLeave: () -> Unit,
+    bottomPadding: Dp = 0.dp
 ) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(Color(0xFFF5F4F2))
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
 
@@ -123,12 +137,9 @@ fun ShareAndPostContent(
                     query = state.emailQuery,
                     onQueryChange = onEmailQueryChange
                 )
-                Spacer(modifier = Modifier.height(10.dp))
-                ShareUserList(
-                    state = state,
-                    onRemoveUser = onRemoveUser
-                )
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+                ShareUserList(state = state, onRemoveUser = onRemoveUser)
+                Spacer(modifier = Modifier.height(16.dp))
                 ShareTeamSection(
                     title = "My Teams",
                     teams = state.myTeams,
@@ -148,6 +159,7 @@ fun ShareAndPostContent(
             ShareBottomBar(onConfirmShare = onConfirmShare)
         }
 
+        // AC-70: Dialog with dark overlay
         if (state.showUnsavedChangesDialog) {
             UnsavedChangesDialog(
                 onDismiss = onDismissUnsavedChanges,
@@ -157,55 +169,65 @@ fun ShareAndPostContent(
     }
 }
 
-// ─── Top bar ─────────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareTopBar(onBackPressed: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .height(80.dp)
-            .background(TopBarColor)
+            .background(Color(0xFFCDE9EA))
     ) {
         Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
+
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .requiredHeight(64.dp)
+                .padding(start = 4.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(RoundedCornerShape(100.dp)),
+                modifier = Modifier.requiredSize(48.dp),
                 contentAlignment = Alignment.Center
             ) {
-                IconButton(onClick = onBackPressed, modifier = Modifier.size(40.dp)) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
-                        tint = Color(0xFF1D1B20),
-                        modifier = Modifier.size(24.dp)
-                    )
+                Box(
+                    modifier = Modifier
+                        .requiredWidth(40.dp)
+                        .clip(RoundedCornerShape(100.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    IconButton(
+                        onClick = onBackPressed,
+                        modifier = Modifier.requiredSize(40.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color(0xFF1D1B20),
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
                 }
             }
-            Spacer(modifier = Modifier.width(4.dp))
+
             Text(
                 text = "Share and post",
+                color = Color(0xFF1D1B20),
                 fontSize = 28.sp,
                 fontWeight = FontWeight.Normal,
-                color = Color(0xFF1D1B20),
+                lineHeight = 1.29.em,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .wrapContentHeight()
-                    .fillMaxWidth()
+                    .weight(1f)
+                    .wrapContentHeight(Alignment.CenterVertically)
             )
+
+            Spacer(modifier = Modifier.requiredWidth(4.dp))
         }
     }
 }
 
-// ─── Search bar ───────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareSearchBar(
@@ -217,39 +239,47 @@ private fun ShareSearchBar(
         modifier = Modifier
             .fillMaxWidth()
             .height(56.dp)
-            .shadow(1.dp, RoundedCornerShape(28.dp))
+            .shadow(2.dp, RoundedCornerShape(28.dp))
             .background(SearchBarBg, RoundedCornerShape(28.dp))
             .padding(horizontal = 4.dp)
     ) {
-        Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+        Box(modifier = Modifier.requiredSize(48.dp), contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = Icons.Default.Search,
                 contentDescription = null,
                 tint = SearchIconColor,
-                modifier = Modifier.size(18.dp)
+                modifier = Modifier.size(24.dp)
             )
         }
         TextField(
             value = query,
             onValueChange = onQueryChange,
             placeholder = {
-                Text("Enter email", color = TextGray, fontSize = 14.sp)
+                Text(
+                    text = "Enter email",
+                    color = SearchIconColor,
+                    fontSize = 16.sp,
+                    lineHeight = 1.5.em
+                )
             },
             singleLine = true,
             colors = TextFieldDefaults.colors(
-                focusedContainerColor = Color.Transparent,
+                focusedContainerColor   = Color.Transparent,
                 unfocusedContainerColor = Color.Transparent,
-                focusedIndicatorColor = Color.Transparent,
+                focusedIndicatorColor   = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
-                cursorColor = TealPrimary
+                cursorColor             = TealPrimary
             ),
             modifier = Modifier.weight(1f),
-            textStyle = LocalTextStyle.current.copy(fontSize = 16.sp)
+            textStyle = LocalTextStyle.current.copy(
+                fontSize = 16.sp,
+                lineHeight = 1.5.em
+            )
         )
+        Spacer(modifier = Modifier.requiredSize(48.dp))
     }
 }
 
-// ─── User list ────────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareUserList(
@@ -267,37 +297,41 @@ private fun ShareUserList(
         visibleUsers.addAll(displayUsers)
     }
 
-    visibleUsers.forEach { user ->
-        key(user.id) {
-            AnimatedVisibility(
-                visible = user in displayUsers,
-                exit = shrinkVertically() + fadeOut()
-            ) {
-                Column {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        visibleUsers.forEach { user ->
+            key(user.id) {
+                AnimatedVisibility(
+                    visible = user in displayUsers,
+                    exit = shrinkVertically() + fadeOut()
+                ) {
                     SelectedUserRow(user = user, onRemove = { onRemoveUser(user) })
-                    Spacer(modifier = Modifier.height(4.dp))
                 }
             }
         }
     }
 }
 
-// ─── Team section ─────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareTeamSection(
     title: String,
-    teams: List<com.oracle.visualize.domain.models.ShareTeam>,
+    teams: List<ShareTeam>,
     emptyMessage: String,
     onToggleTeam: (String) -> Unit
 ) {
     Text(
         text = title,
         fontSize = 16.sp,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.Medium,
         color = TextDark,
-        modifier = Modifier.padding(bottom = 10.dp)
+        lineHeight = 1.5.em,
+        modifier = Modifier
+            .requiredWidth(380.dp)
+            .padding(bottom = 0.dp)
     )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
     if (teams.isEmpty()) {
         Box(
             modifier = Modifier
@@ -307,51 +341,52 @@ private fun ShareTeamSection(
         ) {
             Text(text = emptyMessage, fontSize = 13.sp, color = TextGray)
         }
-    } else {
-        teams.forEach { team ->
-            TeamRow(team = team, onToggle = { onToggleTeam(team.id) })
-            Spacer(modifier = Modifier.height(8.dp))
+        return
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        teams.forEachIndexed { index, team ->
+            val position = when {
+                teams.size == 1 -> TeamRowPosition.SINGLE
+                index == 0      -> TeamRowPosition.TOP
+                index == teams.size - 1 -> TeamRowPosition.BOTTOM
+                else            -> TeamRowPosition.MIDDLE
+            }
+            TeamRow(
+                team = team,
+                onToggle = { onToggleTeam(team.id) },
+                position = position
+            )
         }
     }
 }
 
-// ─── Bottom bar ───────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareBottomBar(onConfirmShare: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(88.dp)
-            .background(TopBarColor)
+            .requiredHeight(136.dp)
+            .background(Color(0xFFCDE9EA))
             .padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Button(
             onClick = onConfirmShare,
-            shape = RoundedCornerShape(100.dp),
+            shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = OrangeButton,
+                containerColor = Color(0xFFEB9632),
                 contentColor = Color.White
             ),
-            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
             modifier = Modifier
-                .width(184.dp)
-                .height(56.dp)
+                .requiredWidth(184.dp)
+                .requiredHeight(56.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Send,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp)
-            )
+            Icon(Icons.Default.Send, contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = "Confirm",
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium,
-                letterSpacing = 0.15.sp
-            )
+            Text("Confirm", fontSize = 16.sp, fontWeight = FontWeight.Medium)
         }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
@@ -1,0 +1,100 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import androidx.lifecycle.ViewModel
+import com.oracle.visualize.domain.models.ShareAndPostState
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.domain.models.ShareUser
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class ShareAndPostViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(ShareAndPostState())
+    val state: StateFlow<ShareAndPostState> = _state.asStateFlow()
+
+    init {
+        // TODO: Replace with real UseCase call when data layer is ready
+        _state.update {
+            it.copy(
+                suggestedUsers = ShareMockData.suggestedUsers,
+                myTeams = ShareMockData.myTeams,
+                teamsImIn = ShareMockData.teamsImIn
+            )
+        }
+    }
+
+    // Replace with real data source (UseCase / Repository) when available
+    fun loadData(myTeams: List<ShareTeam>, teamsImIn: List<ShareTeam>) {
+        _state.update { it.copy(myTeams = myTeams, teamsImIn = teamsImIn) }
+    }
+
+    fun onEmailQueryChange(query: String) {
+        _state.update { it.copy(emailQuery = query) }
+    }
+
+    fun onAddUserByEmail(email: String) {
+        if (email.isBlank()) return
+        val newUser = ShareUser(
+            id = email,
+            name = email.substringBefore("@").replaceFirstChar { it.uppercase() },
+            email = email,
+            avatarInitials = email.first().uppercase()
+        )
+        _state.update {
+            it.copy(selectedUsers = it.selectedUsers + newUser, emailQuery = "")
+        }
+    }
+
+    fun onRemoveUser(user: ShareUser) {
+        _state.update { state ->
+            state.copy(
+                selectedUsers = state.selectedUsers - user,
+                suggestedUsers = state.suggestedUsers - user
+            )
+        }
+    }
+
+    fun onToggleTeam(teamId: String, isMyTeam: Boolean) {
+        _state.update { state ->
+            if (isMyTeam) {
+                state.copy(myTeams = state.myTeams.map { team ->
+                    if (team.id == teamId) team.copy(isSelected = !team.isSelected) else team
+                })
+            } else {
+                state.copy(teamsImIn = state.teamsImIn.map { team ->
+                    if (team.id == teamId) team.copy(isSelected = !team.isSelected) else team
+                })
+            }
+        }
+    }
+
+    fun onConfirmShare() {
+        // TODO: call UseCase to persist share action
+    }
+
+    fun onBackPressed() {
+        val hasSelections = _state.value.selectedUsers.isNotEmpty() ||
+                _state.value.myTeams.any { it.isSelected } ||
+                _state.value.teamsImIn.any { it.isSelected }
+        if (hasSelections) {
+            _state.update { it.copy(showUnsavedChangesDialog = true) }
+        }
+    }
+
+    fun onDismissUnsavedChanges() {
+        _state.update { it.copy(showUnsavedChangesDialog = false) }
+    }
+
+    fun onConfirmLeave() {
+        _state.update {
+            it.copy(
+                showUnsavedChangesDialog = false,
+                selectedUsers = emptyList(),
+                myTeams = it.myTeams.map { t -> t.copy(isSelected = false) },
+                teamsImIn = it.teamsImIn.map { t -> t.copy(isSelected = false) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareMockData.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareMockData.kt
@@ -1,0 +1,81 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.domain.models.ShareUser
+
+// TODO: Remove when real data source (Repository / UseCase) is implemented
+object ShareMockData {
+
+    val suggestedUsers = listOf(
+        ShareUser(
+            id = "u_diana",
+            name = "Diana Escalante",
+            email = "dianaescalante@gmail.com",
+            avatarInitials = "D",
+            avatarColor = 0xFFE8A87C
+        ),
+        ShareUser(
+            id = "u_jocelyn",
+            name = "Jocelyn Duarte",
+            email = "jocelynduarte@gmail.com",
+            avatarInitials = "J",
+            avatarColor = 0xFF7EC8C8
+        ),
+        ShareUser(
+            id = "u_eduardo",
+            name = "Eduardo Salazar",
+            email = "eduardosalazar@gmail.com",
+            avatarInitials = "E",
+            avatarColor = 0xFF8CB87C
+        )
+    )
+
+    val myTeams = listOf(
+        ShareTeam(
+            id = "team_data_1",
+            name = "Data Analyst",
+            memberCount = 2,
+            members = listOf(
+                ShareUser("u1", "Ana",  "ana@gmail.com",  "A", 0xFFE8A87C),
+                ShareUser("u2", "Bob",  "bob@gmail.com",  "B", 0xFF7EC8C8)
+            )
+        ),
+        ShareTeam(
+            id = "team_data_2",
+            name = "Data Analyst",
+            memberCount = 5,
+            members = listOf(
+                ShareUser("u1", "Ana",  "ana@gmail.com",  "A", 0xFFE8A87C),
+                ShareUser("u2", "Bob",  "bob@gmail.com",  "B", 0xFF7EC8C8),
+                ShareUser("u3", "Carl", "carl@gmail.com", "C", 0xFFB8D4E8),
+                ShareUser("u7", "Dana", "dana@gmail.com", "D", 0xFFE8C87C),
+                ShareUser("u8", "Erik", "erik@gmail.com", "E", 0xFF8CB87C)
+            )
+        )
+    )
+
+    val teamsImIn = listOf(
+        ShareTeam(
+            id = "team_in_1",
+            name = "Data Analyst",
+            memberCount = 5,
+            members = listOf(
+                ShareUser("u4", "Diana", "diana@gmail.com", "D", 0xFFE8C87C),
+                ShareUser("u5", "Eve",   "eve@gmail.com",   "E", 0xFF8CB87C),
+                ShareUser("u9", "Frank", "frank@gmail.com", "F", 0xFFB87C8C)
+            )
+        ),
+        ShareTeam(
+            id = "team_in_2",
+            name = "Data Analyst",
+            memberCount = 5,
+            members = listOf(
+                ShareUser("u4",  "Diana", "diana@gmail.com", "D", 0xFFE8C87C),
+                ShareUser("u5",  "Eve",   "eve@gmail.com",   "E", 0xFF8CB87C),
+                ShareUser("u6",  "Frank", "frank@gmail.com", "F", 0xFFB87C8C),
+                ShareUser("u10", "Gina",  "gina@gmail.com",  "G", 0xFF9CB8E8),
+                ShareUser("u11", "Hank",  "hank@gmail.com",  "H", 0xFFE89CB8)
+            )
+        )
+    )
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
@@ -1,12 +1,14 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
@@ -16,11 +18,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareUser
-import com.oracle.visualize.ui.theme.TextDark
+
+private val AVATAR_SIZE = 29.dp
+private val AVATAR_OFFSET = 15.dp
+private val AVATAR_BORDER = Color(0xFFE6EDEC)
 
 private val AVATAR_COLORS = listOf(
     Color(0xFFE8A87C),
@@ -36,30 +42,35 @@ fun MemberAvatarStack(
     isSelected: Boolean
 ) {
     val displayCount = minOf(members.size, 3)
-    val extraCount = members.size - displayCount
+    val extraCount   = members.size - displayCount
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.wrapContentWidth()
     ) {
+        // Stacked avatars box — width = offset*(n-1) + avatarSize
+        val stackWidth = if (displayCount > 0)
+            AVATAR_OFFSET * (displayCount - 1) + AVATAR_SIZE
+        else 0.dp
+
         Box(
             modifier = Modifier
-                .width((displayCount * 14 + 28).dp)
-                .height(28.dp)
+                .width(stackWidth)
+                .height(AVATAR_SIZE)
         ) {
             repeat(displayCount) { index ->
                 Box(
                     modifier = Modifier
-                        .offset(x = (index * 14).dp)
-                        .size(28.dp)
+                        .offset(x = AVATAR_OFFSET * index)
+                        .requiredSize(AVATAR_SIZE)
                         .clip(CircleShape)
-                        .background(AVATAR_COLORS[index % AVATAR_COLORS.size]),
+                        .background(AVATAR_COLORS[index % AVATAR_COLORS.size])
+                        .border(BorderStroke(1.dp, AVATAR_BORDER), CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = members.getOrNull(index)?.avatarInitials ?: "",
-                        fontSize = 10.sp,
-                        fontWeight = FontWeight.Bold,
+                        style = TextStyle(fontSize = 10.sp, fontWeight = FontWeight.Bold),
                         color = Color.White
                     )
                 }
@@ -67,22 +78,21 @@ fun MemberAvatarStack(
         }
 
         if (extraCount > 0) {
-            Spacer(modifier = Modifier.width(4.dp))
+            Spacer(modifier = Modifier.width(1.dp))
             Box(
                 modifier = Modifier
-                    .size(28.dp)
+                    .requiredSize(AVATAR_SIZE)
                     .clip(CircleShape)
                     .background(
-                        if (isSelected) Color.White.copy(alpha = 0.25f)
-                        else Color(0xFFCDD5D8)
-                    ),
+                        if (isSelected) Color.White.copy(alpha = 0.25f) else Color.White
+                    )
+                    .border(BorderStroke(1.dp, AVATAR_BORDER), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = "+$extraCount",
-                    fontSize = 9.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = if (isSelected) Color.White else TextDark
+                    style = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Normal),
+                    color = if (isSelected) Color.White else Color.DarkGray
                 )
             }
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
@@ -1,0 +1,90 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.ui.theme.TextDark
+
+private val AVATAR_COLORS = listOf(
+    Color(0xFFE8A87C),
+    Color(0xFF7EC8C8),
+    Color(0xFFB8D4E8),
+    Color(0xFFE8C87C),
+    Color(0xFF8CB87C)
+)
+
+@Composable
+fun MemberAvatarStack(
+    members: List<ShareUser>,
+    isSelected: Boolean
+) {
+    val displayCount = minOf(members.size, 3)
+    val extraCount = members.size - displayCount
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.wrapContentWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .width((displayCount * 14 + 28).dp)
+                .height(28.dp)
+        ) {
+            repeat(displayCount) { index ->
+                Box(
+                    modifier = Modifier
+                        .offset(x = (index * 14).dp)
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(AVATAR_COLORS[index % AVATAR_COLORS.size]),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = members.getOrNull(index)?.avatarInitials ?: "",
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                }
+            }
+        }
+
+        if (extraCount > 0) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (isSelected) Color.White.copy(alpha = 0.25f)
+                        else Color(0xFFCDD5D8)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "+$extraCount",
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = if (isSelected) Color.White else TextDark
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
@@ -1,12 +1,16 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -17,62 +21,93 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareUser
-import com.oracle.visualize.ui.theme.TextDark
-import com.oracle.visualize.ui.theme.TextGray
 
-private val RemoveRed = Color(0xFFE05555)
+// Figma: card height 68dp, clip RoundedCornerShape(12dp), content offset x=16,y=12
+private val CardShape   = RoundedCornerShape(12.dp)
+private val SubtextColor = Color(0xFF597271)
+private val CloseIconColor = Color(0xFFE05555)
 
 @Composable
 fun SelectedUserRow(
     user: ShareUser,
     onRemove: () -> Unit
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+    // Figma: fillMaxWidth, height 68dp, clip 12dp, white bg
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .shadow(1.dp, RoundedCornerShape(14.dp))
-            .background(Color.White, RoundedCornerShape(14.dp))
-            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .requiredHeight(68.dp)
+            .clip(CardShape)
+            .background(Color.White)
     ) {
-        UserAvatar(
-            initials = user.avatarInitials,
-            color = Color(user.avatarColor),
-            size = 44
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = user.name,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = TextDark
-            )
-            Text(
-                text = user.email,
-                fontSize = 12.sp,
-                color = TextGray,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        IconButton(
-            onClick = onRemove,
-            modifier = Modifier.size(32.dp)
+        // Content: avatar + text, offset x=16, y=12
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .offset(x = 16.dp, y = 12.dp)
+                .requiredWidth(288.dp)
+                .requiredHeight(44.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = "Remove user",
-                tint = RemoveRed,
-                modifier = Modifier.size(16.dp)
+            // Avatar circle with initials
+            UserAvatar(
+                initials = user.avatarInitials,
+                color = Color(user.avatarColor),
+                size = 40
             )
+            // Text column — offset x=56 from avatar
+            Column(
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(x = 56.dp, y = 0.dp)
+                    .requiredWidth(232.dp)
+                    .requiredHeight(44.dp)
+            ) {
+                Text(
+                    text = user.name,
+                    color = Color(0xFF1D1B20),
+                    fontSize = 16.sp,
+                    lineHeight = 1.5.em,
+                    fontWeight = FontWeight.Normal
+                )
+                Text(
+                    text = user.email,
+                    color = SubtextColor,
+                    fontSize = 14.sp,
+                    lineHeight = 1.43.em,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        // Close button — Figma: offset x=339, y=20
+        Row(
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp, Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .offset(x = 339.dp, y = 20.dp)
+        ) {
+            IconButton(
+                onClick = onRemove,
+                modifier = Modifier.requiredSize(24.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Remove user",
+                    tint = CloseIconColor,
+                    modifier = Modifier.requiredSize(16.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
@@ -1,0 +1,78 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+
+private val RemoveRed = Color(0xFFE05555)
+
+@Composable
+fun SelectedUserRow(
+    user: ShareUser,
+    onRemove: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(1.dp, RoundedCornerShape(14.dp))
+            .background(Color.White, RoundedCornerShape(14.dp))
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        UserAvatar(
+            initials = user.avatarInitials,
+            color = Color(user.avatarColor),
+            size = 44
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = user.name,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = TextDark
+            )
+            Text(
+                text = user.email,
+                fontSize = 12.sp,
+                color = TextGray,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        IconButton(
+            onClick = onRemove,
+            modifier = Modifier.size(32.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Remove user",
+                tint = RemoveRed,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
@@ -1,62 +1,95 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
+import androidx.compose.animation.animateColorAsState
+
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.ui.theme.TealPrimary
 import com.oracle.visualize.ui.theme.TextDark
-import com.oracle.visualize.ui.theme.TextGray
 
-private val TealSelected = Color(0xFF3D8C84)
 private val TeamUnselectedBg = Color(0xFFE5ECEB)
+private val SubtextSelected  = Color(0xFFCDE9EA)
+private val SubtextUnselected = Color(0xFF597271)
+
+val ShapeTop    = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp, bottomStart = 5.dp, bottomEnd = 5.dp)
+val ShapeMiddle = RoundedCornerShape(5.dp)
+val ShapeBottom = RoundedCornerShape(topStart = 5.dp, topEnd = 5.dp, bottomStart = 15.dp, bottomEnd = 15.dp)
+val ShapeSingle = RoundedCornerShape(15.dp)
+
+enum class TeamRowPosition { SINGLE, TOP, MIDDLE, BOTTOM }
 
 @Composable
 fun TeamRow(
     team: ShareTeam,
-    onToggle: () -> Unit
+    onToggle: () -> Unit,
+    position: TeamRowPosition = TeamRowPosition.SINGLE
 ) {
-    val bgColor = if (team.isSelected) TealSelected else TeamUnselectedBg
+    val shape = when (position) {
+        TeamRowPosition.TOP    -> ShapeTop
+        TeamRowPosition.MIDDLE -> ShapeMiddle
+        TeamRowPosition.BOTTOM -> ShapeBottom
+        TeamRowPosition.SINGLE -> ShapeSingle
+    }
+
+    val targetBg = if (team.isSelected) TealPrimary else TeamUnselectedBg
+    val animatedBg by animateColorAsState(
+        targetValue = targetBg,
+        animationSpec = tween(200),
+        label = "teamBg"
+    )
     val textColor = if (team.isSelected) Color.White else TextDark
-    val subColor = if (team.isSelected) Color.White.copy(alpha = 0.85f) else TextGray
+    val subColor  = if (team.isSelected) SubtextSelected else SubtextUnselected
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .shadow(if (team.isSelected) 0.dp else 2.dp, RoundedCornerShape(14.dp))
-            .background(bgColor, RoundedCornerShape(14.dp))
-            .clickable { onToggle() }
-            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .clip(shape)
+            .background(animatedBg)
+            .clickable {
+                onToggle() }
+            .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         Column(modifier = Modifier.weight(1f)) {
+            Spacer(modifier = Modifier.height(5.dp))
             Text(
                 text = team.name,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = textColor
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Normal,
+                color = textColor,
+                lineHeight = 24.sp
             )
+            Spacer(modifier = Modifier.height(5.dp))
             Text(
                 text = "${team.memberCount} members",
-                fontSize = 12.sp,
-                color = subColor
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Normal,
+                color = subColor,
+                lineHeight = 20.sp
             )
         }
-        MemberAvatarStack(
-            members = team.members,
-            isSelected = team.isSelected
-        )
+        MemberAvatarStack(members = team.members, isSelected = team.isSelected)
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
@@ -1,0 +1,62 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+
+private val TealSelected = Color(0xFF3D8C84)
+private val TeamUnselectedBg = Color(0xFFE5ECEB)
+
+@Composable
+fun TeamRow(
+    team: ShareTeam,
+    onToggle: () -> Unit
+) {
+    val bgColor = if (team.isSelected) TealSelected else TeamUnselectedBg
+    val textColor = if (team.isSelected) Color.White else TextDark
+    val subColor = if (team.isSelected) Color.White.copy(alpha = 0.85f) else TextGray
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(if (team.isSelected) 0.dp else 2.dp, RoundedCornerShape(14.dp))
+            .background(bgColor, RoundedCornerShape(14.dp))
+            .clickable { onToggle() }
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = team.name,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = textColor
+            )
+            Text(
+                text = "${team.memberCount} members",
+                fontSize = 12.sp,
+                color = subColor
+            )
+        }
+        MemberAvatarStack(
+            members = team.members,
+            isSelected = team.isSelected
+        )
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
@@ -1,0 +1,81 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+import com.oracle.visualize.ui.theme.TealPrimary
+
+@Composable
+fun UnsavedChangesDialog(
+    onDismiss: () -> Unit,
+    onConfirmLeave: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .background(Color.White, RoundedCornerShape(20.dp))
+                .padding(horizontal = 24.dp, vertical = 28.dp)
+        ) {
+            Text(
+                text = "Unsaved Changes",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Normal,
+                color = TextDark
+            )
+            Spacer(modifier = Modifier.height(14.dp))
+            Text(
+                text = "You have unsaved changes. Are you sure you want to leave?",
+                fontSize = 14.sp,
+                color = TextGray,
+                lineHeight = 21.sp
+            )
+            Spacer(modifier = Modifier.height(28.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(
+                        text = "Cancel",
+                        color = TextGray,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 15.sp
+                    )
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                TextButton(onClick = onConfirmLeave) {
+                    Text(
+                        text = "Share",
+                        color = TealPrimary,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
@@ -1,13 +1,15 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -17,12 +19,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.oracle.visualize.ui.theme.TextDark
-import com.oracle.visualize.ui.theme.TextGray
 import com.oracle.visualize.ui.theme.TealPrimary
+
+// Figma AC-70: overlay Color(0xFF1A2F3F) alpha 0.2, dialog offset x=50, width=312, corners=28dp
+private val OverlayColor   = Color(0xFF1A2F3F).copy(alpha = 0.2f)
+private val DialogBg       = Color.White
+private val TitleColor     = Color(0xFF1D1B20)
+private val BodyColor      = Color(0xFF49454F)
 
 @Composable
 fun UnsavedChangesDialog(
@@ -33,47 +40,66 @@ fun UnsavedChangesDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Column(
+        Box(
             modifier = Modifier
-                .fillMaxWidth(0.9f)
-                .background(Color.White, RoundedCornerShape(20.dp))
-                .padding(horizontal = 24.dp, vertical = 28.dp)
+                .fillMaxSize()
+                .background(OverlayColor),
+            contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = "Unsaved Changes",
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Normal,
-                color = TextDark
-            )
-            Spacer(modifier = Modifier.height(14.dp))
-            Text(
-                text = "You have unsaved changes. Are you sure you want to leave?",
-                fontSize = 14.sp,
-                color = TextGray,
-                lineHeight = 21.sp
-            )
-            Spacer(modifier = Modifier.height(28.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically
+            Column(
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier
+                    .fillMaxWidth(0.76f)
+                    .background(DialogBg, RoundedCornerShape(28.dp))
             ) {
-                TextButton(onClick = onDismiss) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 24.dp, top = 24.dp)
+                ) {
                     Text(
-                        text = "Cancel",
-                        color = TextGray,
-                        fontWeight = FontWeight.Medium,
-                        fontSize = 15.sp
+                        text = "Unsaved Changes",
+                        color = TitleColor,
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Normal,
+                        lineHeight = 1.33.em
+                    )
+                    Text(
+                        text = "You have unsaved changes. Are you sure you want to leave?",
+                        color = BodyColor,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Normal,
+                        lineHeight = 1.43.em
                     )
                 }
-                Spacer(modifier = Modifier.width(16.dp))
-                TextButton(onClick = onConfirmLeave) {
-                    Text(
-                        text = "Share",
-                        color = TealPrimary,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 15.sp
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(
+                        start = 8.dp, end = 24.dp,
+                        top = 20.dp, bottom = 20.dp
                     )
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(
+                            text = "Cancel",
+                            color = TealPrimary,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            lineHeight = 1.43.em
+                        )
+                    }
+                    TextButton(onClick = onConfirmLeave) {
+                        Text(
+                            text = "Share",
+                            color = TealPrimary,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            lineHeight = 1.43.em
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UserAvatar.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UserAvatar.kt
@@ -1,0 +1,37 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun UserAvatar(
+    initials: String,
+    color: Color,
+    size: Int = 38
+) {
+    Box(
+        modifier = Modifier
+            .size(size.dp)
+            .clip(CircleShape)
+            .background(color),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            fontSize = (size * 0.37f).sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/ui/theme/Color.kt
+++ b/app/src/main/java/com/oracle/visualize/ui/theme/Color.kt
@@ -20,11 +20,16 @@ val LightGreen = Color(0xFFCDE9EA)
 val ScreenBackground = Color(0xFFF5F4F2)
 val TopBarColor = Color(0xFFCDE9EA)
 val TealPrimary = Color(0xFF34797C)
-val TealLight = Color(0xFFCDE9EA) // Use TopBar color as the light variant
+val TealLight = Color(0xFFCDE9EA)
 val TextDark = Color(0xFF13212C)
 val TextGray = Color(0xFF323232)
 val BorderGray = Color(0xFFCCCCCC)
 val OrangeButton = Color(0xFFE69138)
+
+// Share screen
+val TealSelected = Color(0xFF3D8C84)
+val TeamUnselectedBg = Color(0xFFE5ECEB)
+val RemoveRed = Color(0xFFE05555)
 
 // Error states
 val ErrorRed = Color(0xFFD32F2F)
@@ -35,14 +40,3 @@ val NavBarBackground = Color(0xFFCDE9EA)
 val NavBarSelected = Color(0xFF34797C)
 val NavBarIconUnselected = Color(0xFF4A454E)
 val NavBarIconSelected = Color(0xFFFFFFFF)
-
-/*
-the colors of the various elements of a navigation item.
-Params:
-selectedIconColor - the color to use for the icon when the item is selected.
-selectedTextColor - the color to use for the text label when the item is selected.
-selectedIndicatorColor - the color to use for the indicator when the item is selected.
-unselectedIconColor - the color to use for the icon when the item is unselected.
-unselectedTextColor - the color to use for the text label when the item is unselected.
-disabledIconColor - the color to use for the icon when the item is disabled.
-disabledTextColor - the color to use for the text label when the item is disabled.*/


### PR DESCRIPTION
Add share and post screen matching Figma AC-67, AC-66 and AC-70

Files changed:
- ShareAndPostView.kt: screen moved outside Scaffold, top bar full width
  and no shadow, Confirm button aligned to end, bottom bar moved outside
  scrollable Column, background #F5F4F2, search bar placeholder #7FA9A9
- TeamRow.kt: asymmetric corners per position, colors and subtext matched
  to Figma, 200ms color animation, bounded ripple on click
- MemberAvatarStack.kt: avatar 29dp, offset 15dp, border 1dp #E6EDEC,
  badge 29dp DarkGray text 13sp
- SelectedUserRow.kt: height 68dp, clip 12dp, content x=16 y=12,
  close button x=339 y=20
- UnsavedChangesDialog.kt: overlay #1A2F3F alpha 0.2, width 76%,
  corners 28dp, title 24sp, body 14sp #49454F

Problem:
Screen had visual deviations from Figma. Navbar was visible, bottom bar
was hidden inside the scrollable Column, and components had incorrect
sizes, colors and corner shapes.

Solution:
Screen moved outside main Scaffold to render full screen. Each component
updated with exact values from Figma AC-67, AC-66 and AC-70 source code.