### PR TITLE
Refactor ShareScreen architecture based on code review feedback

### DIFF
--- a/app/src/main/java/com/oracle/visualize/domain/models/NavRoutes.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/NavRoutes.kt
@@ -3,11 +3,8 @@ package com.oracle.visualize.domain.models
 sealed class NavRoutes(val route: String) {
     object Feed : NavRoutes("feed")
     object Notifications : NavRoutes("notifications")
-
     object Profile : NavRoutes("profile")
-
     object Teams : NavRoutes("teams")
-
     object Create : NavRoutes("create")
-
+    object Share : NavRoutes("share")
 }

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareAndPostState.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareAndPostState.kt
@@ -1,0 +1,10 @@
+package com.oracle.visualize.domain.models
+
+data class ShareAndPostState(
+    val emailQuery: String = "",
+    val selectedUsers: List<ShareUser> = emptyList(),
+    val suggestedUsers: List<ShareUser> = emptyList(),
+    val myTeams: List<ShareTeam> = emptyList(),
+    val teamsImIn: List<ShareTeam> = emptyList(),
+    val showUnsavedChangesDialog: Boolean = false
+)

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
@@ -1,0 +1,9 @@
+package com.oracle.visualize.domain.models
+
+data class ShareTeam(
+    val id: String,
+    val name: String,
+    val memberCount: Int,
+    val members: List<ShareUser> = emptyList(),
+    val isSelected: Boolean = false
+)

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
@@ -4,6 +4,7 @@ data class ShareTeam(
     val id: String,
     val name: String,
     val memberCount: Int,
-    val members: List<ShareUser> = emptyList(),
-    val isSelected: Boolean = false
+    val members: List<ShareUser> = emptyList()
+    // Note: isSelected was removed — selection is UI state,
+    // not a property of the business entity.
 )

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareUser.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareUser.kt
@@ -1,0 +1,9 @@
+package com.oracle.visualize.domain.models
+
+data class ShareUser(
+    val id: String,
+    val name: String,
+    val email: String,
+    val avatarInitials: String,
+    val avatarColor: Long = 0xFFE8A87C
+)

--- a/app/src/main/java/com/oracle/visualize/domain/models/User.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/User.kt
@@ -6,8 +6,8 @@ data class User (
     val email: String,
     val userName: String,
     val profilePictureUrl: String?,
-    val themePreference: String, // Pending: Memory optimization
-    val chartTheme: String, // Pending: Memory optimization
+    val themePreference: String,
+    val chartTheme: String,
     val notificationsEnabled: Boolean,
     val tokens: List<String>
 )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.oracle.visualize.domain.models.NavRoutes
@@ -17,11 +19,17 @@ import com.oracle.visualize.presentation.screens.ShareScreen.ShareAndPostScreen
 import com.oracle.visualize.ui.theme.ScreenBackground
 
 @Composable
-fun MainScreen(
-    viewModel: MainViewModel = viewModel()
-) {
+fun MainScreen(viewModel: MainViewModel = viewModel()) {
     val currentRoute by viewModel.currentRoute.collectAsStateWithLifecycle()
     val selectedIndex by viewModel.selectedIndex.collectAsStateWithLifecycle()
+
+    // Share screen ocupa pantalla completa, sin navbar
+    if (currentRoute == NavRoutes.Share.route) {
+        ShareAndPostScreen(
+            onNavigateBack = { viewModel.onNavItemSelected(2) }
+        )
+        return
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -37,7 +45,7 @@ fun MainScreen(
         ContentScreen(
             modifier = Modifier.padding(innerPadding),
             currentRoute = currentRoute,
-            onNavigateBack = { viewModel.onNavItemSelected(2) } // Back to Feed
+            onNavigateBack = { viewModel.onNavItemSelected(2) }
         )
     }
 }
@@ -46,13 +54,16 @@ fun MainScreen(
 fun ContentScreen(
     modifier: Modifier = Modifier,
     currentRoute: String,
-    onNavigateBack: () -> Unit = {}
+    onNavigateBack: () -> Unit = {},
+    bottomPadding: Dp = 0.dp
 ) {
     when (currentRoute) {
         NavRoutes.Feed.route -> FeedPage(modifier = modifier)
         NavRoutes.Notifications.route -> NotificationPage(modifier = modifier)
         NavRoutes.Create.route -> CreatePage(modifier = modifier)
-        NavRoutes.Share.route -> ShareAndPostScreen(onNavigateBack = onNavigateBack)
-        // Add other routes as they are implemented
+        NavRoutes.Share.route -> ShareAndPostScreen(
+            onNavigateBack = onNavigateBack,
+            bottomPadding =  bottomPadding
+        )
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
@@ -23,7 +23,6 @@ fun MainScreen(viewModel: MainViewModel = viewModel()) {
     val currentRoute by viewModel.currentRoute.collectAsStateWithLifecycle()
     val selectedIndex by viewModel.selectedIndex.collectAsStateWithLifecycle()
 
-    // Share screen ocupa pantalla completa, sin navbar
     if (currentRoute == NavRoutes.Share.route) {
         ShareAndPostScreen(
             onNavigateBack = { viewModel.onNavItemSelected(2) }
@@ -63,7 +62,6 @@ fun ContentScreen(
         NavRoutes.Create.route -> CreatePage(modifier = modifier)
         NavRoutes.Share.route -> ShareAndPostScreen(
             onNavigateBack = onNavigateBack,
-            bottomPadding =  bottomPadding
         )
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
@@ -8,18 +8,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.oracle.visualize.presentation.components.BottomNavBar
 import com.oracle.visualize.domain.models.NavRoutes
+import com.oracle.visualize.presentation.components.BottomNavBar
+import com.oracle.visualize.presentation.screens.CreateScreen.CreatePage
 import com.oracle.visualize.presentation.screens.FeedScreen.FeedPage
 import com.oracle.visualize.presentation.screens.NotificationScreen.NotificationPage
-import com.oracle.visualize.presentation.screens.CreateScreen.CreatePage
+import com.oracle.visualize.presentation.screens.ShareScreen.ShareAndPostScreen
 import com.oracle.visualize.ui.theme.ScreenBackground
 
 @Composable
 fun MainScreen(
     viewModel: MainViewModel = viewModel()
 ) {
-    //We obtain the state from View
     val currentRoute by viewModel.currentRoute.collectAsStateWithLifecycle()
     val selectedIndex by viewModel.selectedIndex.collectAsStateWithLifecycle()
 
@@ -29,31 +29,30 @@ fun MainScreen(
             BottomNavBar(
                 navItems = viewModel.navItems,
                 selectedIndex = selectedIndex,
-                onItemSelected = viewModel::onNavItemSelected //Update the state
-
+                onItemSelected = viewModel::onNavItemSelected
             )
         },
         containerColor = ScreenBackground
     ) { innerPadding ->
         ContentScreen(
             modifier = Modifier.padding(innerPadding),
-            currentRoute = currentRoute //Update the screen type
+            currentRoute = currentRoute,
+            onNavigateBack = { viewModel.onNavItemSelected(2) } // Back to Feed
         )
     }
 }
 
-
-
-
 @Composable
 fun ContentScreen(
     modifier: Modifier = Modifier,
-    currentRoute: String
+    currentRoute: String,
+    onNavigateBack: () -> Unit = {}
 ) {
     when (currentRoute) {
         NavRoutes.Feed.route -> FeedPage(modifier = modifier)
         NavRoutes.Notifications.route -> NotificationPage(modifier = modifier)
         NavRoutes.Create.route -> CreatePage(modifier = modifier)
+        NavRoutes.Share.route -> ShareAndPostScreen(onNavigateBack = onNavigateBack)
         // Add other routes as they are implemented
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
 class MainViewModel : ViewModel() {
 
     //State
-    private val route = MutableStateFlow(NavRoutes.Feed.route)
+    private val route = MutableStateFlow(NavRoutes.Share.route)
     private val index = MutableStateFlow(2)
 
 

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
@@ -39,6 +39,7 @@ fun ShareAndPostScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    // Load mock data as if it came from a Repository — ViewModel stays clean
     LaunchedEffect(Unit) {
         viewModel.loadData(
             myTeams      = ShareMockData.myTeams,
@@ -58,7 +59,7 @@ fun ShareAndPostScreen(
             ShareAndPostContent(
                 state = state,
                 onEvent = { event ->
-
+                    // Navigation side effects handled here, not in ViewModel
                     when (event) {
                         is ShareUiEvent.BackPressed -> {
                             if (!state.hasChanges) onNavigateBack()
@@ -87,7 +88,7 @@ fun ShareAndPostScreen(
 @Composable
 fun ShareAndPostContent(
     state: ShareUiState.Content,
-    onEvent: (ShareUiEvent) -> Unit
+    onEvent: (ShareUiEvent) -> Unit   // Single event callback replaces 9+ lambdas
 ) {
     Box(modifier = Modifier.fillMaxSize().background(AppColors.screenBackground)) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -233,7 +234,7 @@ private fun ShareUserList(state: ShareUiState.Content, onEvent: (ShareUiEvent) -
 private fun ShareTeamSection(
     title: String,
     teams: List<ShareTeam>,
-    selectedTeamIds: Set<String>,
+    selectedTeamIds: Set<String>,   // Selection state lives here, not in the entity
     emptyMessage: String,
     onToggleTeam: (String) -> Unit
 ) {
@@ -259,7 +260,7 @@ private fun ShareTeamSection(
             }
             TeamRow(
                 team = team,
-                isSelected = team.id in selectedTeamIds,
+                isSelected = team.id in selectedTeamIds,  // selection from state, not entity
                 onToggle = { onToggleTeam(team.id) },
                 position = position
             )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
@@ -1,0 +1,357 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsTopHeight
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.oracle.visualize.domain.models.ShareAndPostState
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.presentation.screens.ShareScreen.components.SelectedUserRow
+import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRow
+import com.oracle.visualize.presentation.screens.ShareScreen.components.UnsavedChangesDialog
+import com.oracle.visualize.ui.theme.OrangeButton
+import com.oracle.visualize.ui.theme.TealPrimary
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+import com.oracle.visualize.ui.theme.TopBarColor
+
+private val SearchBarBg = Color(0xFFF5F5F5)
+private val SearchIconColor = Color(0xFF7FA9A9)
+
+@Composable
+fun ShareAndPostScreen(
+    viewModel: ShareAndPostViewModel = viewModel(),
+    onNavigateBack: () -> Unit = {}
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    ShareAndPostContent(
+        state = state,
+        onEmailQueryChange = viewModel::onEmailQueryChange,
+        onAddUserByEmail = viewModel::onAddUserByEmail,
+        onRemoveUser = viewModel::onRemoveUser,
+        onToggleTeam = viewModel::onToggleTeam,
+        onConfirmShare = viewModel::onConfirmShare,
+        onBackPressed = {
+            val hadSelections = state.selectedUsers.isNotEmpty() ||
+                    state.myTeams.any { it.isSelected } ||
+                    state.teamsImIn.any { it.isSelected }
+            if (hadSelections) viewModel.onBackPressed() else onNavigateBack()
+        },
+        onDismissUnsavedChanges = viewModel::onDismissUnsavedChanges,
+        onConfirmLeave = { viewModel.onConfirmLeave(); onNavigateBack() }
+    )
+}
+
+@Composable
+fun ShareAndPostContent(
+    state: ShareAndPostState,
+    onEmailQueryChange: (String) -> Unit,
+    onAddUserByEmail: (String) -> Unit,
+    onRemoveUser: (ShareUser) -> Unit,
+    onToggleTeam: (String, Boolean) -> Unit,
+    onConfirmShare: () -> Unit,
+    onBackPressed: () -> Unit,
+    onDismissUnsavedChanges: () -> Unit,
+    onConfirmLeave: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+
+            ShareTopBar(onBackPressed = onBackPressed)
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+            ) {
+                Spacer(modifier = Modifier.height(16.dp))
+                ShareSearchBar(
+                    query = state.emailQuery,
+                    onQueryChange = onEmailQueryChange
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                ShareUserList(
+                    state = state,
+                    onRemoveUser = onRemoveUser
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                ShareTeamSection(
+                    title = "My Teams",
+                    teams = state.myTeams,
+                    emptyMessage = "You haven't created any teams yet.",
+                    onToggleTeam = { id -> onToggleTeam(id, true) }
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                ShareTeamSection(
+                    title = "Teams I'm In",
+                    teams = state.teamsImIn,
+                    emptyMessage = "You're not part of any teams yet.",
+                    onToggleTeam = { id -> onToggleTeam(id, false) }
+                )
+                Spacer(modifier = Modifier.height(80.dp))
+            }
+
+            ShareBottomBar(onConfirmShare = onConfirmShare)
+        }
+
+        if (state.showUnsavedChangesDialog) {
+            UnsavedChangesDialog(
+                onDismiss = onDismissUnsavedChanges,
+                onConfirmLeave = onConfirmLeave
+            )
+        }
+    }
+}
+
+// ─── Top bar ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareTopBar(onBackPressed: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(80.dp)
+            .background(TopBarColor)
+    ) {
+        Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(100.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                IconButton(onClick = onBackPressed, modifier = Modifier.size(40.dp)) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = Color(0xFF1D1B20),
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = "Share and post",
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Normal,
+                color = Color(0xFF1D1B20),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .wrapContentHeight()
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+// ─── Search bar ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .shadow(1.dp, RoundedCornerShape(28.dp))
+            .background(SearchBarBg, RoundedCornerShape(28.dp))
+            .padding(horizontal = 4.dp)
+    ) {
+        Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = SearchIconColor,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+        TextField(
+            value = query,
+            onValueChange = onQueryChange,
+            placeholder = {
+                Text("Enter email", color = TextGray, fontSize = 14.sp)
+            },
+            singleLine = true,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                cursorColor = TealPrimary
+            ),
+            modifier = Modifier.weight(1f),
+            textStyle = LocalTextStyle.current.copy(fontSize = 16.sp)
+        )
+    }
+}
+
+// ─── User list ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareUserList(
+    state: ShareAndPostState,
+    onRemoveUser: (ShareUser) -> Unit
+) {
+    val displayUsers = if (state.selectedUsers.isNotEmpty()) state.selectedUsers
+    else state.suggestedUsers
+
+    if (displayUsers.isEmpty()) return
+
+    val visibleUsers = remember { mutableStateListOf(*displayUsers.toTypedArray()) }
+    LaunchedEffect(displayUsers) {
+        visibleUsers.clear()
+        visibleUsers.addAll(displayUsers)
+    }
+
+    visibleUsers.forEach { user ->
+        key(user.id) {
+            AnimatedVisibility(
+                visible = user in displayUsers,
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                Column {
+                    SelectedUserRow(user = user, onRemove = { onRemoveUser(user) })
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+        }
+    }
+}
+
+// ─── Team section ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareTeamSection(
+    title: String,
+    teams: List<com.oracle.visualize.domain.models.ShareTeam>,
+    emptyMessage: String,
+    onToggleTeam: (String) -> Unit
+) {
+    Text(
+        text = title,
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Bold,
+        color = TextDark,
+        modifier = Modifier.padding(bottom = 10.dp)
+    )
+    if (teams.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = emptyMessage, fontSize = 13.sp, color = TextGray)
+        }
+    } else {
+        teams.forEach { team ->
+            TeamRow(team = team, onToggle = { onToggleTeam(team.id) })
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+// ─── Bottom bar ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun ShareBottomBar(onConfirmShare: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(88.dp)
+            .background(TopBarColor)
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Button(
+            onClick = onConfirmShare,
+            shape = RoundedCornerShape(100.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = OrangeButton,
+                contentColor = Color.White
+            ),
+            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+            modifier = Modifier
+                .width(184.dp)
+                .height(56.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Send,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Confirm",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.15.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
@@ -14,7 +14,11 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
@@ -48,14 +52,18 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.oracle.visualize.domain.models.ShareAndPostState
+import com.oracle.visualize.domain.models.ShareTeam
 import com.oracle.visualize.domain.models.ShareUser
 import com.oracle.visualize.presentation.screens.ShareScreen.components.SelectedUserRow
 import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRow
+import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRowPosition
 import com.oracle.visualize.presentation.screens.ShareScreen.components.UnsavedChangesDialog
 import com.oracle.visualize.ui.theme.OrangeButton
 import com.oracle.visualize.ui.theme.TealPrimary
@@ -63,13 +71,16 @@ import com.oracle.visualize.ui.theme.TextDark
 import com.oracle.visualize.ui.theme.TextGray
 import com.oracle.visualize.ui.theme.TopBarColor
 
-private val SearchBarBg = Color(0xFFF5F5F5)
+private val SearchBarBg   = Color(0xFFF5F4F2)
 private val SearchIconColor = Color(0xFF7FA9A9)
+
+
 
 @Composable
 fun ShareAndPostScreen(
     viewModel: ShareAndPostViewModel = viewModel(),
-    onNavigateBack: () -> Unit = {}
+    onNavigateBack: () -> Unit = {},
+    bottomPadding: Dp = 0.dp
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -87,9 +98,11 @@ fun ShareAndPostScreen(
             if (hadSelections) viewModel.onBackPressed() else onNavigateBack()
         },
         onDismissUnsavedChanges = viewModel::onDismissUnsavedChanges,
-        onConfirmLeave = { viewModel.onConfirmLeave(); onNavigateBack() }
+        onConfirmLeave = { viewModel.onConfirmLeave(); onNavigateBack() },
+        bottomPadding = bottomPadding
     )
 }
+
 
 @Composable
 fun ShareAndPostContent(
@@ -101,12 +114,13 @@ fun ShareAndPostContent(
     onConfirmShare: () -> Unit,
     onBackPressed: () -> Unit,
     onDismissUnsavedChanges: () -> Unit,
-    onConfirmLeave: () -> Unit
+    onConfirmLeave: () -> Unit,
+    bottomPadding: Dp = 0.dp
 ) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(Color(0xFFF5F4F2))
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
 
@@ -123,12 +137,9 @@ fun ShareAndPostContent(
                     query = state.emailQuery,
                     onQueryChange = onEmailQueryChange
                 )
-                Spacer(modifier = Modifier.height(10.dp))
-                ShareUserList(
-                    state = state,
-                    onRemoveUser = onRemoveUser
-                )
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+                ShareUserList(state = state, onRemoveUser = onRemoveUser)
+                Spacer(modifier = Modifier.height(16.dp))
                 ShareTeamSection(
                     title = "My Teams",
                     teams = state.myTeams,
@@ -148,6 +159,7 @@ fun ShareAndPostContent(
             ShareBottomBar(onConfirmShare = onConfirmShare)
         }
 
+        // AC-70: Dialog with dark overlay
         if (state.showUnsavedChangesDialog) {
             UnsavedChangesDialog(
                 onDismiss = onDismissUnsavedChanges,
@@ -157,55 +169,65 @@ fun ShareAndPostContent(
     }
 }
 
-// ─── Top bar ─────────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareTopBar(onBackPressed: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .height(80.dp)
-            .background(TopBarColor)
+            .background(Color(0xFFCDE9EA))
     ) {
         Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
+
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .requiredHeight(64.dp)
+                .padding(start = 4.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(RoundedCornerShape(100.dp)),
+                modifier = Modifier.requiredSize(48.dp),
                 contentAlignment = Alignment.Center
             ) {
-                IconButton(onClick = onBackPressed, modifier = Modifier.size(40.dp)) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
-                        tint = Color(0xFF1D1B20),
-                        modifier = Modifier.size(24.dp)
-                    )
+                Box(
+                    modifier = Modifier
+                        .requiredWidth(40.dp)
+                        .clip(RoundedCornerShape(100.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    IconButton(
+                        onClick = onBackPressed,
+                        modifier = Modifier.requiredSize(40.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color(0xFF1D1B20),
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
                 }
             }
-            Spacer(modifier = Modifier.width(4.dp))
+
             Text(
                 text = "Share and post",
+                color = Color(0xFF1D1B20),
                 fontSize = 28.sp,
                 fontWeight = FontWeight.Normal,
-                color = Color(0xFF1D1B20),
+                lineHeight = 1.29.em,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .wrapContentHeight()
-                    .fillMaxWidth()
+                    .weight(1f)
+                    .wrapContentHeight(Alignment.CenterVertically)
             )
+
+            Spacer(modifier = Modifier.requiredWidth(4.dp))
         }
     }
 }
 
-// ─── Search bar ───────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareSearchBar(
@@ -217,39 +239,47 @@ private fun ShareSearchBar(
         modifier = Modifier
             .fillMaxWidth()
             .height(56.dp)
-            .shadow(1.dp, RoundedCornerShape(28.dp))
+            .shadow(2.dp, RoundedCornerShape(28.dp))
             .background(SearchBarBg, RoundedCornerShape(28.dp))
             .padding(horizontal = 4.dp)
     ) {
-        Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+        Box(modifier = Modifier.requiredSize(48.dp), contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = Icons.Default.Search,
                 contentDescription = null,
                 tint = SearchIconColor,
-                modifier = Modifier.size(18.dp)
+                modifier = Modifier.size(24.dp)
             )
         }
         TextField(
             value = query,
             onValueChange = onQueryChange,
             placeholder = {
-                Text("Enter email", color = TextGray, fontSize = 14.sp)
+                Text(
+                    text = "Enter email",
+                    color = SearchIconColor,
+                    fontSize = 16.sp,
+                    lineHeight = 1.5.em
+                )
             },
             singleLine = true,
             colors = TextFieldDefaults.colors(
-                focusedContainerColor = Color.Transparent,
+                focusedContainerColor   = Color.Transparent,
                 unfocusedContainerColor = Color.Transparent,
-                focusedIndicatorColor = Color.Transparent,
+                focusedIndicatorColor   = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
-                cursorColor = TealPrimary
+                cursorColor             = TealPrimary
             ),
             modifier = Modifier.weight(1f),
-            textStyle = LocalTextStyle.current.copy(fontSize = 16.sp)
+            textStyle = LocalTextStyle.current.copy(
+                fontSize = 16.sp,
+                lineHeight = 1.5.em
+            )
         )
+        Spacer(modifier = Modifier.requiredSize(48.dp))
     }
 }
 
-// ─── User list ────────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareUserList(
@@ -267,37 +297,41 @@ private fun ShareUserList(
         visibleUsers.addAll(displayUsers)
     }
 
-    visibleUsers.forEach { user ->
-        key(user.id) {
-            AnimatedVisibility(
-                visible = user in displayUsers,
-                exit = shrinkVertically() + fadeOut()
-            ) {
-                Column {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        visibleUsers.forEach { user ->
+            key(user.id) {
+                AnimatedVisibility(
+                    visible = user in displayUsers,
+                    exit = shrinkVertically() + fadeOut()
+                ) {
                     SelectedUserRow(user = user, onRemove = { onRemoveUser(user) })
-                    Spacer(modifier = Modifier.height(4.dp))
                 }
             }
         }
     }
 }
 
-// ─── Team section ─────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareTeamSection(
     title: String,
-    teams: List<com.oracle.visualize.domain.models.ShareTeam>,
+    teams: List<ShareTeam>,
     emptyMessage: String,
     onToggleTeam: (String) -> Unit
 ) {
     Text(
         text = title,
         fontSize = 16.sp,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.Medium,
         color = TextDark,
-        modifier = Modifier.padding(bottom = 10.dp)
+        lineHeight = 1.5.em,
+        modifier = Modifier
+            .requiredWidth(380.dp)
+            .padding(bottom = 0.dp)
     )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
     if (teams.isEmpty()) {
         Box(
             modifier = Modifier
@@ -307,51 +341,52 @@ private fun ShareTeamSection(
         ) {
             Text(text = emptyMessage, fontSize = 13.sp, color = TextGray)
         }
-    } else {
-        teams.forEach { team ->
-            TeamRow(team = team, onToggle = { onToggleTeam(team.id) })
-            Spacer(modifier = Modifier.height(8.dp))
+        return
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        teams.forEachIndexed { index, team ->
+            val position = when {
+                teams.size == 1 -> TeamRowPosition.SINGLE
+                index == 0      -> TeamRowPosition.TOP
+                index == teams.size - 1 -> TeamRowPosition.BOTTOM
+                else            -> TeamRowPosition.MIDDLE
+            }
+            TeamRow(
+                team = team,
+                onToggle = { onToggleTeam(team.id) },
+                position = position
+            )
         }
     }
 }
 
-// ─── Bottom bar ───────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareBottomBar(onConfirmShare: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(88.dp)
-            .background(TopBarColor)
+            .requiredHeight(136.dp)
+            .background(Color(0xFFCDE9EA))
             .padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Button(
             onClick = onConfirmShare,
-            shape = RoundedCornerShape(100.dp),
+            shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = OrangeButton,
+                containerColor = Color(0xFFEB9632),
                 contentColor = Color.White
             ),
-            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
             modifier = Modifier
-                .width(184.dp)
-                .height(56.dp)
+                .requiredWidth(184.dp)
+                .requiredHeight(56.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Send,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp)
-            )
+            Icon(Icons.Default.Send, contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = "Confirm",
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium,
-                letterSpacing = 0.15.sp
-            )
+            Text("Confirm", fontSize = 16.sp, fontWeight = FontWeight.Medium)
         }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostView.kt
@@ -4,26 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsTopHeight
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -31,100 +12,87 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Send
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.oracle.visualize.domain.models.ShareAndPostState
 import com.oracle.visualize.domain.models.ShareTeam
 import com.oracle.visualize.domain.models.ShareUser
-import com.oracle.visualize.presentation.screens.ShareScreen.components.SelectedUserRow
-import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRow
-import com.oracle.visualize.presentation.screens.ShareScreen.components.TeamRowPosition
-import com.oracle.visualize.presentation.screens.ShareScreen.components.UnsavedChangesDialog
-import com.oracle.visualize.ui.theme.OrangeButton
-import com.oracle.visualize.ui.theme.TealPrimary
-import com.oracle.visualize.ui.theme.TextDark
-import com.oracle.visualize.ui.theme.TextGray
-import com.oracle.visualize.ui.theme.TopBarColor
+import com.oracle.visualize.presentation.screens.ShareScreen.components.*
+import com.oracle.visualize.ui.theme.AppColors
 
-private val SearchBarBg   = Color(0xFFF5F4F2)
-private val SearchIconColor = Color(0xFF7FA9A9)
-
-
+// ─── Entry point ──────────────────────────────────────────────────────────────
 
 @Composable
 fun ShareAndPostScreen(
     viewModel: ShareAndPostViewModel = viewModel(),
-    onNavigateBack: () -> Unit = {},
-    bottomPadding: Dp = 0.dp
+    onNavigateBack: () -> Unit = {}
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    ShareAndPostContent(
-        state = state,
-        onEmailQueryChange = viewModel::onEmailQueryChange,
-        onAddUserByEmail = viewModel::onAddUserByEmail,
-        onRemoveUser = viewModel::onRemoveUser,
-        onToggleTeam = viewModel::onToggleTeam,
-        onConfirmShare = viewModel::onConfirmShare,
-        onBackPressed = {
-            val hadSelections = state.selectedUsers.isNotEmpty() ||
-                    state.myTeams.any { it.isSelected } ||
-                    state.teamsImIn.any { it.isSelected }
-            if (hadSelections) viewModel.onBackPressed() else onNavigateBack()
-        },
-        onDismissUnsavedChanges = viewModel::onDismissUnsavedChanges,
-        onConfirmLeave = { viewModel.onConfirmLeave(); onNavigateBack() },
-        bottomPadding = bottomPadding
-    )
+    LaunchedEffect(Unit) {
+        viewModel.loadData(
+            myTeams      = ShareMockData.myTeams,
+            teamsImIn    = ShareMockData.teamsImIn,
+            suggestedUsers = ShareMockData.suggestedUsers
+        )
+    }
+
+    when (val state = uiState) {
+        is ShareUiState.Loading -> {
+            Box(modifier = Modifier.fillMaxSize().background(AppColors.screenBackground),
+                contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = AppColors.tealPrimary)
+            }
+        }
+        is ShareUiState.Content -> {
+            ShareAndPostContent(
+                state = state,
+                onEvent = { event ->
+
+                    when (event) {
+                        is ShareUiEvent.BackPressed -> {
+                            if (!state.hasChanges) onNavigateBack()
+                            else viewModel.onEvent(event)
+                        }
+                        is ShareUiEvent.ConfirmLeave -> {
+                            viewModel.onEvent(event)
+                            onNavigateBack()
+                        }
+                        else -> viewModel.onEvent(event)
+                    }
+                }
+            )
+        }
+        is ShareUiState.Error -> {
+            Box(modifier = Modifier.fillMaxSize().background(AppColors.screenBackground),
+                contentAlignment = Alignment.Center) {
+                Text(text = state.message, color = AppColors.errorRed)
+            }
+        }
+    }
 }
 
+// ─── Main content ─────────────────────────────────────────────────────────────
 
 @Composable
 fun ShareAndPostContent(
-    state: ShareAndPostState,
-    onEmailQueryChange: (String) -> Unit,
-    onAddUserByEmail: (String) -> Unit,
-    onRemoveUser: (ShareUser) -> Unit,
-    onToggleTeam: (String, Boolean) -> Unit,
-    onConfirmShare: () -> Unit,
-    onBackPressed: () -> Unit,
-    onDismissUnsavedChanges: () -> Unit,
-    onConfirmLeave: () -> Unit,
-    bottomPadding: Dp = 0.dp
+    state: ShareUiState.Content,
+    onEvent: (ShareUiEvent) -> Unit
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color(0xFFF5F4F2))
-    ) {
+    Box(modifier = Modifier.fillMaxSize().background(AppColors.screenBackground)) {
         Column(modifier = Modifier.fillMaxSize()) {
 
-            ShareTopBar(onBackPressed = onBackPressed)
+            ShareTopBar(onBackPressed = { onEvent(ShareUiEvent.BackPressed) })
 
             Column(
                 modifier = Modifier
@@ -135,211 +103,148 @@ fun ShareAndPostContent(
                 Spacer(modifier = Modifier.height(16.dp))
                 ShareSearchBar(
                     query = state.emailQuery,
-                    onQueryChange = onEmailQueryChange
+                    onQueryChange = { onEvent(ShareUiEvent.EmailQueryChanged(it)) }
                 )
                 Spacer(modifier = Modifier.height(12.dp))
-                ShareUserList(state = state, onRemoveUser = onRemoveUser)
+                ShareUserList(state = state, onEvent = onEvent)
                 Spacer(modifier = Modifier.height(16.dp))
                 ShareTeamSection(
                     title = "My Teams",
                     teams = state.myTeams,
+                    selectedTeamIds = state.selectedTeamIds,
                     emptyMessage = "You haven't created any teams yet.",
-                    onToggleTeam = { id -> onToggleTeam(id, true) }
+                    onToggleTeam = { id -> onEvent(ShareUiEvent.ToggleTeam(id, isMyTeam = true)) }
                 )
                 Spacer(modifier = Modifier.height(16.dp))
                 ShareTeamSection(
                     title = "Teams I'm In",
                     teams = state.teamsImIn,
+                    selectedTeamIds = state.selectedTeamIds,
                     emptyMessage = "You're not part of any teams yet.",
-                    onToggleTeam = { id -> onToggleTeam(id, false) }
+                    onToggleTeam = { id -> onEvent(ShareUiEvent.ToggleTeam(id, isMyTeam = false)) }
                 )
                 Spacer(modifier = Modifier.height(80.dp))
             }
 
-            ShareBottomBar(onConfirmShare = onConfirmShare)
+            ShareBottomBar(onConfirmShare = { onEvent(ShareUiEvent.ConfirmShare) })
         }
 
-        // AC-70: Dialog with dark overlay
         if (state.showUnsavedChangesDialog) {
             UnsavedChangesDialog(
-                onDismiss = onDismissUnsavedChanges,
-                onConfirmLeave = onConfirmLeave
+                onDismiss = { onEvent(ShareUiEvent.DismissUnsavedChanges) },
+                onConfirmLeave = { onEvent(ShareUiEvent.ConfirmLeave) }
             )
         }
     }
 }
 
+// ─── Top bar ──────────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareTopBar(onBackPressed: () -> Unit) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(Color(0xFFCDE9EA))
-    ) {
+    Column(modifier = Modifier.fillMaxWidth().background(AppColors.topBarColor)) {
         Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
-
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .requiredHeight(64.dp)
-                .padding(start = 4.dp)
+            modifier = Modifier.fillMaxWidth().requiredHeight(64.dp).padding(start = 4.dp)
         ) {
-            Box(
-                modifier = Modifier.requiredSize(48.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Box(
-                    modifier = Modifier
-                        .requiredWidth(40.dp)
-                        .clip(RoundedCornerShape(100.dp)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    IconButton(
-                        onClick = onBackPressed,
-                        modifier = Modifier.requiredSize(40.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
-                            tint = Color(0xFF1D1B20),
-                            modifier = Modifier.size(24.dp)
-                        )
+            Box(modifier = Modifier.requiredSize(48.dp), contentAlignment = Alignment.Center) {
+                Box(modifier = Modifier.requiredWidth(40.dp).clip(RoundedCornerShape(100.dp)), contentAlignment = Alignment.Center) {
+                    IconButton(onClick = onBackPressed, modifier = Modifier.requiredSize(40.dp)) {
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = AppColors.textDark, modifier = Modifier.size(24.dp))
                     }
                 }
             }
-
             Text(
                 text = "Share and post",
-                color = Color(0xFF1D1B20),
+                color = AppColors.textDark,
                 fontSize = 28.sp,
                 fontWeight = FontWeight.Normal,
                 lineHeight = 1.29.em,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .weight(1f)
-                    .wrapContentHeight(Alignment.CenterVertically)
+                modifier = Modifier.weight(1f).wrapContentHeight(Alignment.CenterVertically)
             )
-
             Spacer(modifier = Modifier.requiredWidth(4.dp))
         }
     }
 }
 
+// ─── Search bar ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun ShareSearchBar(
-    query: String,
-    onQueryChange: (String) -> Unit
-) {
+private fun ShareSearchBar(query: String, onQueryChange: (String) -> Unit) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .shadow(2.dp, RoundedCornerShape(28.dp))
-            .background(SearchBarBg, RoundedCornerShape(28.dp))
+            .fillMaxWidth().height(56.dp)
+            .clip(RoundedCornerShape(28.dp))
+            .background(AppColors.searchBarBg)
             .padding(horizontal = 4.dp)
     ) {
         Box(modifier = Modifier.requiredSize(48.dp), contentAlignment = Alignment.Center) {
-            Icon(
-                imageVector = Icons.Default.Search,
-                contentDescription = null,
-                tint = SearchIconColor,
-                modifier = Modifier.size(24.dp)
-            )
+            Icon(imageVector = Icons.Default.Search, contentDescription = null, tint = AppColors.textMuted, modifier = Modifier.size(24.dp))
         }
         TextField(
             value = query,
             onValueChange = onQueryChange,
-            placeholder = {
-                Text(
-                    text = "Enter email",
-                    color = SearchIconColor,
-                    fontSize = 16.sp,
-                    lineHeight = 1.5.em
-                )
-            },
+            placeholder = { Text("Enter email", color = AppColors.textMuted, fontSize = 16.sp) },
             singleLine = true,
             colors = TextFieldDefaults.colors(
                 focusedContainerColor   = Color.Transparent,
                 unfocusedContainerColor = Color.Transparent,
                 focusedIndicatorColor   = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
-                cursorColor             = TealPrimary
+                cursorColor             = AppColors.tealPrimary,
+                focusedTextColor        = AppColors.textDark,
+                unfocusedTextColor      = AppColors.textDark
             ),
             modifier = Modifier.weight(1f),
-            textStyle = LocalTextStyle.current.copy(
-                fontSize = 16.sp,
-                lineHeight = 1.5.em
-            )
+            textStyle = LocalTextStyle.current.copy(fontSize = 16.sp)
         )
         Spacer(modifier = Modifier.requiredSize(48.dp))
     }
 }
 
+// ─── User list ────────────────────────────────────────────────────────────────
 
 @Composable
-private fun ShareUserList(
-    state: ShareAndPostState,
-    onRemoveUser: (ShareUser) -> Unit
-) {
-    val displayUsers = if (state.selectedUsers.isNotEmpty()) state.selectedUsers
-    else state.suggestedUsers
-
+private fun ShareUserList(state: ShareUiState.Content, onEvent: (ShareUiEvent) -> Unit) {
+    val displayUsers = if (state.selectedUsers.isNotEmpty()) state.selectedUsers else state.suggestedUsers
     if (displayUsers.isEmpty()) return
 
     val visibleUsers = remember { mutableStateListOf(*displayUsers.toTypedArray()) }
-    LaunchedEffect(displayUsers) {
-        visibleUsers.clear()
-        visibleUsers.addAll(displayUsers)
-    }
+    LaunchedEffect(displayUsers) { visibleUsers.clear(); visibleUsers.addAll(displayUsers) }
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         visibleUsers.forEach { user ->
             key(user.id) {
-                AnimatedVisibility(
-                    visible = user in displayUsers,
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    SelectedUserRow(user = user, onRemove = { onRemoveUser(user) })
+                AnimatedVisibility(visible = user in displayUsers, exit = shrinkVertically() + fadeOut()) {
+                    SelectedUserRow(user = user, onRemove = { onEvent(ShareUiEvent.RemoveUser(user)) })
                 }
             }
         }
     }
 }
 
+// ─── Team section ─────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareTeamSection(
     title: String,
     teams: List<ShareTeam>,
+    selectedTeamIds: Set<String>,
     emptyMessage: String,
     onToggleTeam: (String) -> Unit
 ) {
-    Text(
-        text = title,
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Medium,
-        color = TextDark,
-        lineHeight = 1.5.em,
-        modifier = Modifier
-            .requiredWidth(380.dp)
-            .padding(bottom = 0.dp)
-    )
-
+    Text(text = title, fontSize = 16.sp, fontWeight = FontWeight.Medium,
+        color = AppColors.sectionTitle, lineHeight = 1.5.em,
+        modifier = Modifier.requiredWidth(380.dp))
     Spacer(modifier = Modifier.height(8.dp))
 
     if (teams.isEmpty()) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(text = emptyMessage, fontSize = 13.sp, color = TextGray)
+        Box(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), contentAlignment = Alignment.Center) {
+            Text(text = emptyMessage, fontSize = 13.sp, color = AppColors.textGray)
         }
         return
     }
@@ -347,13 +252,14 @@ private fun ShareTeamSection(
     Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
         teams.forEachIndexed { index, team ->
             val position = when {
-                teams.size == 1 -> TeamRowPosition.SINGLE
-                index == 0      -> TeamRowPosition.TOP
+                teams.size == 1         -> TeamRowPosition.SINGLE
+                index == 0              -> TeamRowPosition.TOP
                 index == teams.size - 1 -> TeamRowPosition.BOTTOM
-                else            -> TeamRowPosition.MIDDLE
+                else                    -> TeamRowPosition.MIDDLE
             }
             TeamRow(
                 team = team,
+                isSelected = team.id in selectedTeamIds,
                 onToggle = { onToggleTeam(team.id) },
                 position = position
             )
@@ -361,30 +267,23 @@ private fun ShareTeamSection(
     }
 }
 
+// ─── Bottom bar ───────────────────────────────────────────────────────────────
 
 @Composable
 private fun ShareBottomBar(onConfirmShare: () -> Unit) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .requiredHeight(136.dp)
-            .background(Color(0xFFCDE9EA))
-            .padding(horizontal = 16.dp),
+        modifier = Modifier.fillMaxWidth().requiredHeight(136.dp)
+            .background(AppColors.topBarColor).padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Button(
             onClick = onConfirmShare,
             shape = RoundedCornerShape(16.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color(0xFFEB9632),
-                contentColor = Color.White
-            ),
-            modifier = Modifier
-                .requiredWidth(184.dp)
-                .requiredHeight(56.dp)
+            colors = ButtonDefaults.buttonColors(containerColor = AppColors.orangeButton, contentColor = Color.White),
+            modifier = Modifier.requiredWidth(184.dp).requiredHeight(56.dp)
         ) {
-            Icon(Icons.Default.Send, contentDescription = null, modifier = Modifier.size(24.dp))
+            Icon(imageVector = Icons.Default.Send, contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.width(8.dp))
             Text("Confirm", fontSize = 16.sp, fontWeight = FontWeight.Medium)
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
@@ -13,7 +13,6 @@ class ShareAndPostViewModel : ViewModel() {
     private val _uiState = MutableStateFlow<ShareUiState>(ShareUiState.Loading)
     val uiState: StateFlow<ShareUiState> = _uiState.asStateFlow()
 
-    // Called from the screen entry point with data from Repository/UseCase
     fun loadData(
         myTeams: List<ShareTeam>,
         teamsImIn: List<ShareTeam>,
@@ -69,7 +68,7 @@ class ShareAndPostViewModel : ViewModel() {
                 if (current.hasChanges) {
                     current.copy(showUnsavedChangesDialog = true)
                 } else {
-                    current // Navigation handled by the View observing hasChanges
+                    current
                 }
             }
 
@@ -85,13 +84,11 @@ class ShareAndPostViewModel : ViewModel() {
                 )
 
             is ShareUiEvent.ConfirmShare -> {
-                // TODO: call UseCase to persist share action
                 current
             }
         }
     }
 
-    // ViewModel decides when there are unsaved changes — UI stays dumb
     private fun computeHasChanges(state: ShareUiState.Content): Boolean =
         state.selectedUsers.isNotEmpty() || state.selectedTeamIds.isNotEmpty()
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
@@ -1,0 +1,100 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import androidx.lifecycle.ViewModel
+import com.oracle.visualize.domain.models.ShareAndPostState
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.domain.models.ShareUser
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class ShareAndPostViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(ShareAndPostState())
+    val state: StateFlow<ShareAndPostState> = _state.asStateFlow()
+
+    init {
+        // TODO: Replace with real UseCase call when data layer is ready
+        _state.update {
+            it.copy(
+                suggestedUsers = ShareMockData.suggestedUsers,
+                myTeams = ShareMockData.myTeams,
+                teamsImIn = ShareMockData.teamsImIn
+            )
+        }
+    }
+
+    // Replace with real data source (UseCase / Repository) when available
+    fun loadData(myTeams: List<ShareTeam>, teamsImIn: List<ShareTeam>) {
+        _state.update { it.copy(myTeams = myTeams, teamsImIn = teamsImIn) }
+    }
+
+    fun onEmailQueryChange(query: String) {
+        _state.update { it.copy(emailQuery = query) }
+    }
+
+    fun onAddUserByEmail(email: String) {
+        if (email.isBlank()) return
+        val newUser = ShareUser(
+            id = email,
+            name = email.substringBefore("@").replaceFirstChar { it.uppercase() },
+            email = email,
+            avatarInitials = email.first().uppercase()
+        )
+        _state.update {
+            it.copy(selectedUsers = it.selectedUsers + newUser, emailQuery = "")
+        }
+    }
+
+    fun onRemoveUser(user: ShareUser) {
+        _state.update { state ->
+            state.copy(
+                selectedUsers = state.selectedUsers - user,
+                suggestedUsers = state.suggestedUsers - user
+            )
+        }
+    }
+
+    fun onToggleTeam(teamId: String, isMyTeam: Boolean) {
+        _state.update { state ->
+            if (isMyTeam) {
+                state.copy(myTeams = state.myTeams.map { team ->
+                    if (team.id == teamId) team.copy(isSelected = !team.isSelected) else team
+                })
+            } else {
+                state.copy(teamsImIn = state.teamsImIn.map { team ->
+                    if (team.id == teamId) team.copy(isSelected = !team.isSelected) else team
+                })
+            }
+        }
+    }
+
+    fun onConfirmShare() {
+        // TODO: call UseCase to persist share action
+    }
+
+    fun onBackPressed() {
+        val hasSelections = _state.value.selectedUsers.isNotEmpty() ||
+                _state.value.myTeams.any { it.isSelected } ||
+                _state.value.teamsImIn.any { it.isSelected }
+        if (hasSelections) {
+            _state.update { it.copy(showUnsavedChangesDialog = true) }
+        }
+    }
+
+    fun onDismissUnsavedChanges() {
+        _state.update { it.copy(showUnsavedChangesDialog = false) }
+    }
+
+    fun onConfirmLeave() {
+        _state.update {
+            it.copy(
+                showUnsavedChangesDialog = false,
+                selectedUsers = emptyList(),
+                myTeams = it.myTeams.map { t -> t.copy(isSelected = false) },
+                teamsImIn = it.teamsImIn.map { t -> t.copy(isSelected = false) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
@@ -84,6 +84,7 @@ class ShareAndPostViewModel : ViewModel() {
                 )
 
             is ShareUiEvent.ConfirmShare -> {
+                // TODO: call UseCase to persist share action
                 current
             }
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareAndPostViewModel.kt
@@ -1,7 +1,6 @@
 package com.oracle.visualize.presentation.screens.ShareScreen
 
 import androidx.lifecycle.ViewModel
-import com.oracle.visualize.domain.models.ShareAndPostState
 import com.oracle.visualize.domain.models.ShareTeam
 import com.oracle.visualize.domain.models.ShareUser
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,90 +10,88 @@ import kotlinx.coroutines.flow.update
 
 class ShareAndPostViewModel : ViewModel() {
 
-    private val _state = MutableStateFlow(ShareAndPostState())
-    val state: StateFlow<ShareAndPostState> = _state.asStateFlow()
+    private val _uiState = MutableStateFlow<ShareUiState>(ShareUiState.Loading)
+    val uiState: StateFlow<ShareUiState> = _uiState.asStateFlow()
 
-    init {
-        // TODO: Replace with real UseCase call when data layer is ready
-        _state.update {
-            it.copy(
-                suggestedUsers = ShareMockData.suggestedUsers,
-                myTeams = ShareMockData.myTeams,
-                teamsImIn = ShareMockData.teamsImIn
-            )
-        }
-    }
-
-    // Replace with real data source (UseCase / Repository) when available
-    fun loadData(myTeams: List<ShareTeam>, teamsImIn: List<ShareTeam>) {
-        _state.update { it.copy(myTeams = myTeams, teamsImIn = teamsImIn) }
-    }
-
-    fun onEmailQueryChange(query: String) {
-        _state.update { it.copy(emailQuery = query) }
-    }
-
-    fun onAddUserByEmail(email: String) {
-        if (email.isBlank()) return
-        val newUser = ShareUser(
-            id = email,
-            name = email.substringBefore("@").replaceFirstChar { it.uppercase() },
-            email = email,
-            avatarInitials = email.first().uppercase()
+    // Called from the screen entry point with data from Repository/UseCase
+    fun loadData(
+        myTeams: List<ShareTeam>,
+        teamsImIn: List<ShareTeam>,
+        suggestedUsers: List<ShareUser> = emptyList()
+    ) {
+        _uiState.value = ShareUiState.Content(
+            myTeams = myTeams,
+            teamsImIn = teamsImIn,
+            suggestedUsers = suggestedUsers
         )
-        _state.update {
-            it.copy(selectedUsers = it.selectedUsers + newUser, emailQuery = "")
-        }
     }
 
-    fun onRemoveUser(user: ShareUser) {
-        _state.update { state ->
-            state.copy(
-                selectedUsers = state.selectedUsers - user,
-                suggestedUsers = state.suggestedUsers - user
-            )
-        }
-    }
+    fun onEvent(event: ShareUiEvent) {
+        val current = _uiState.value as? ShareUiState.Content ?: return
+        _uiState.value = when (event) {
 
-    fun onToggleTeam(teamId: String, isMyTeam: Boolean) {
-        _state.update { state ->
-            if (isMyTeam) {
-                state.copy(myTeams = state.myTeams.map { team ->
-                    if (team.id == teamId) team.copy(isSelected = !team.isSelected) else team
-                })
-            } else {
-                state.copy(teamsImIn = state.teamsImIn.map { team ->
-                    if (team.id == teamId) team.copy(isSelected = !team.isSelected) else team
-                })
+            is ShareUiEvent.EmailQueryChanged ->
+                current.copy(emailQuery = event.query)
+
+            is ShareUiEvent.AddUserByEmail -> {
+                if (event.email.isBlank()) return
+                val newUser = ShareUser(
+                    id = event.email,
+                    name = event.email.substringBefore("@").replaceFirstChar { it.uppercase() },
+                    email = event.email,
+                    avatarInitials = event.email.first().uppercase()
+                )
+                val updated = current.copy(
+                    selectedUsers = current.selectedUsers + newUser,
+                    emailQuery = ""
+                )
+                updated.copy(hasChanges = computeHasChanges(updated))
+            }
+
+            is ShareUiEvent.RemoveUser -> {
+                val updated = current.copy(
+                    selectedUsers = current.selectedUsers - event.user,
+                    suggestedUsers = current.suggestedUsers - event.user
+                )
+                updated.copy(hasChanges = computeHasChanges(updated))
+            }
+
+            is ShareUiEvent.ToggleTeam -> {
+                val updated = if (event.teamId in current.selectedTeamIds) {
+                    current.copy(selectedTeamIds = current.selectedTeamIds - event.teamId)
+                } else {
+                    current.copy(selectedTeamIds = current.selectedTeamIds + event.teamId)
+                }
+                updated.copy(hasChanges = computeHasChanges(updated))
+            }
+
+            is ShareUiEvent.BackPressed -> {
+                if (current.hasChanges) {
+                    current.copy(showUnsavedChangesDialog = true)
+                } else {
+                    current // Navigation handled by the View observing hasChanges
+                }
+            }
+
+            is ShareUiEvent.DismissUnsavedChanges ->
+                current.copy(showUnsavedChangesDialog = false)
+
+            is ShareUiEvent.ConfirmLeave ->
+                current.copy(
+                    showUnsavedChangesDialog = false,
+                    selectedUsers = emptyList(),
+                    selectedTeamIds = emptySet(),
+                    hasChanges = false
+                )
+
+            is ShareUiEvent.ConfirmShare -> {
+                // TODO: call UseCase to persist share action
+                current
             }
         }
     }
 
-    fun onConfirmShare() {
-        // TODO: call UseCase to persist share action
-    }
-
-    fun onBackPressed() {
-        val hasSelections = _state.value.selectedUsers.isNotEmpty() ||
-                _state.value.myTeams.any { it.isSelected } ||
-                _state.value.teamsImIn.any { it.isSelected }
-        if (hasSelections) {
-            _state.update { it.copy(showUnsavedChangesDialog = true) }
-        }
-    }
-
-    fun onDismissUnsavedChanges() {
-        _state.update { it.copy(showUnsavedChangesDialog = false) }
-    }
-
-    fun onConfirmLeave() {
-        _state.update {
-            it.copy(
-                showUnsavedChangesDialog = false,
-                selectedUsers = emptyList(),
-                myTeams = it.myTeams.map { t -> t.copy(isSelected = false) },
-                teamsImIn = it.teamsImIn.map { t -> t.copy(isSelected = false) }
-            )
-        }
-    }
+    // ViewModel decides when there are unsaved changes — UI stays dumb
+    private fun computeHasChanges(state: ShareUiState.Content): Boolean =
+        state.selectedUsers.isNotEmpty() || state.selectedTeamIds.isNotEmpty()
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareMockData.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareMockData.kt
@@ -3,47 +3,27 @@ package com.oracle.visualize.presentation.screens.ShareScreen
 import com.oracle.visualize.domain.models.ShareTeam
 import com.oracle.visualize.domain.models.ShareUser
 
-// TODO: Remove when real data source (Repository / UseCase) is implemented
+// TODO: Remove when Repository / UseCase layer is implemented.
+// Mock data is kept here and passed INTO the ViewModel via loadData(),
+// keeping the ViewModel ready to receive real data from any source.
 object ShareMockData {
 
     val suggestedUsers = listOf(
-        ShareUser(
-            id = "u_diana",
-            name = "Diana Escalante",
-            email = "dianaescalante@gmail.com",
-            avatarInitials = "D",
-            avatarColor = 0xFFE8A87C
-        ),
-        ShareUser(
-            id = "u_jocelyn",
-            name = "Jocelyn Duarte",
-            email = "jocelynduarte@gmail.com",
-            avatarInitials = "J",
-            avatarColor = 0xFF7EC8C8
-        ),
-        ShareUser(
-            id = "u_eduardo",
-            name = "Eduardo Salazar",
-            email = "eduardosalazar@gmail.com",
-            avatarInitials = "E",
-            avatarColor = 0xFF8CB87C
-        )
+        ShareUser("u_diana",   "Diana Escalante", "dianaescalante@gmail.com",  "D", 0xFFE8A87C),
+        ShareUser("u_jocelyn", "Jocelyn Duarte",  "jocelynduarte@gmail.com",   "J", 0xFF7EC8C8),
+        ShareUser("u_eduardo", "Eduardo Salazar", "eduardosalazar@gmail.com",  "E", 0xFF8CB87C)
     )
 
     val myTeams = listOf(
         ShareTeam(
-            id = "team_data_1",
-            name = "Data Analyst",
-            memberCount = 2,
+            id = "team_data_1", name = "Data Analyst", memberCount = 2,
             members = listOf(
-                ShareUser("u1", "Ana",  "ana@gmail.com",  "A", 0xFFE8A87C),
-                ShareUser("u2", "Bob",  "bob@gmail.com",  "B", 0xFF7EC8C8)
+                ShareUser("u1", "Ana", "ana@gmail.com", "A", 0xFFE8A87C),
+                ShareUser("u2", "Bob", "bob@gmail.com", "B", 0xFF7EC8C8)
             )
         ),
         ShareTeam(
-            id = "team_data_2",
-            name = "Data Analyst",
-            memberCount = 5,
+            id = "team_data_2", name = "Data Analyst", memberCount = 5,
             members = listOf(
                 ShareUser("u1", "Ana",  "ana@gmail.com",  "A", 0xFFE8A87C),
                 ShareUser("u2", "Bob",  "bob@gmail.com",  "B", 0xFF7EC8C8),
@@ -56,9 +36,7 @@ object ShareMockData {
 
     val teamsImIn = listOf(
         ShareTeam(
-            id = "team_in_1",
-            name = "Data Analyst",
-            memberCount = 5,
+            id = "team_in_1", name = "Data Analyst", memberCount = 5,
             members = listOf(
                 ShareUser("u4", "Diana", "diana@gmail.com", "D", 0xFFE8C87C),
                 ShareUser("u5", "Eve",   "eve@gmail.com",   "E", 0xFF8CB87C),
@@ -66,9 +44,7 @@ object ShareMockData {
             )
         ),
         ShareTeam(
-            id = "team_in_2",
-            name = "Data Analyst",
-            memberCount = 5,
+            id = "team_in_2", name = "Data Analyst", memberCount = 5,
             members = listOf(
                 ShareUser("u4",  "Diana", "diana@gmail.com", "D", 0xFFE8C87C),
                 ShareUser("u5",  "Eve",   "eve@gmail.com",   "E", 0xFF8CB87C),

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareMockData.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareMockData.kt
@@ -1,0 +1,81 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.domain.models.ShareUser
+
+// TODO: Remove when real data source (Repository / UseCase) is implemented
+object ShareMockData {
+
+    val suggestedUsers = listOf(
+        ShareUser(
+            id = "u_diana",
+            name = "Diana Escalante",
+            email = "dianaescalante@gmail.com",
+            avatarInitials = "D",
+            avatarColor = 0xFFE8A87C
+        ),
+        ShareUser(
+            id = "u_jocelyn",
+            name = "Jocelyn Duarte",
+            email = "jocelynduarte@gmail.com",
+            avatarInitials = "J",
+            avatarColor = 0xFF7EC8C8
+        ),
+        ShareUser(
+            id = "u_eduardo",
+            name = "Eduardo Salazar",
+            email = "eduardosalazar@gmail.com",
+            avatarInitials = "E",
+            avatarColor = 0xFF8CB87C
+        )
+    )
+
+    val myTeams = listOf(
+        ShareTeam(
+            id = "team_data_1",
+            name = "Data Analyst",
+            memberCount = 2,
+            members = listOf(
+                ShareUser("u1", "Ana",  "ana@gmail.com",  "A", 0xFFE8A87C),
+                ShareUser("u2", "Bob",  "bob@gmail.com",  "B", 0xFF7EC8C8)
+            )
+        ),
+        ShareTeam(
+            id = "team_data_2",
+            name = "Data Analyst",
+            memberCount = 5,
+            members = listOf(
+                ShareUser("u1", "Ana",  "ana@gmail.com",  "A", 0xFFE8A87C),
+                ShareUser("u2", "Bob",  "bob@gmail.com",  "B", 0xFF7EC8C8),
+                ShareUser("u3", "Carl", "carl@gmail.com", "C", 0xFFB8D4E8),
+                ShareUser("u7", "Dana", "dana@gmail.com", "D", 0xFFE8C87C),
+                ShareUser("u8", "Erik", "erik@gmail.com", "E", 0xFF8CB87C)
+            )
+        )
+    )
+
+    val teamsImIn = listOf(
+        ShareTeam(
+            id = "team_in_1",
+            name = "Data Analyst",
+            memberCount = 5,
+            members = listOf(
+                ShareUser("u4", "Diana", "diana@gmail.com", "D", 0xFFE8C87C),
+                ShareUser("u5", "Eve",   "eve@gmail.com",   "E", 0xFF8CB87C),
+                ShareUser("u9", "Frank", "frank@gmail.com", "F", 0xFFB87C8C)
+            )
+        ),
+        ShareTeam(
+            id = "team_in_2",
+            name = "Data Analyst",
+            memberCount = 5,
+            members = listOf(
+                ShareUser("u4",  "Diana", "diana@gmail.com", "D", 0xFFE8C87C),
+                ShareUser("u5",  "Eve",   "eve@gmail.com",   "E", 0xFF8CB87C),
+                ShareUser("u6",  "Frank", "frank@gmail.com", "F", 0xFFB87C8C),
+                ShareUser("u10", "Gina",  "gina@gmail.com",  "G", 0xFF9CB8E8),
+                ShareUser("u11", "Hank",  "hank@gmail.com",  "H", 0xFFE89CB8)
+            )
+        )
+    )
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareUiEvent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareUiEvent.kt
@@ -1,0 +1,19 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import com.oracle.visualize.domain.models.ShareUser
+
+/**
+ * Represents all possible UI events from the Share and Post screen.
+ * Replaces 9+ individual lambda parameters with a single onEvent callback,
+ * decoupling the UI from the specific ViewModel implementation.
+ */
+sealed interface ShareUiEvent {
+    data class EmailQueryChanged(val query: String) : ShareUiEvent
+    data class AddUserByEmail(val email: String) : ShareUiEvent
+    data class RemoveUser(val user: ShareUser) : ShareUiEvent
+    data class ToggleTeam(val teamId: String, val isMyTeam: Boolean) : ShareUiEvent
+    object ConfirmShare : ShareUiEvent
+    object BackPressed : ShareUiEvent
+    object DismissUnsavedChanges : ShareUiEvent
+    object ConfirmLeave : ShareUiEvent
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareUiState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/ShareUiState.kt
@@ -1,0 +1,27 @@
+package com.oracle.visualize.presentation.screens.ShareScreen
+
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.domain.models.ShareUser
+
+/**
+ * Represents the UI state of the Share and Post screen.
+ * Moved to presentation layer — UI state has no concern with business logic.
+ * Follows the sealed interface pattern established by CreateUiState.
+ */
+sealed interface ShareUiState {
+
+    object Loading : ShareUiState
+
+    data class Content(
+        val emailQuery: String = "",
+        val selectedUsers: List<ShareUser> = emptyList(),
+        val suggestedUsers: List<ShareUser> = emptyList(),
+        val myTeams: List<ShareTeam> = emptyList(),
+        val teamsImIn: List<ShareTeam> = emptyList(),
+        val selectedTeamIds: Set<String> = emptySet(),
+        val hasChanges: Boolean = false,
+        val showUnsavedChangesDialog: Boolean = false
+    ) : ShareUiState
+
+    data class Error(val message: String) : ShareUiState
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
@@ -1,12 +1,14 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
@@ -16,11 +18,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareUser
-import com.oracle.visualize.ui.theme.TextDark
+
+private val AVATAR_SIZE = 29.dp
+private val AVATAR_OFFSET = 15.dp
+private val AVATAR_BORDER = Color(0xFFE6EDEC)
 
 private val AVATAR_COLORS = listOf(
     Color(0xFFE8A87C),
@@ -36,30 +42,35 @@ fun MemberAvatarStack(
     isSelected: Boolean
 ) {
     val displayCount = minOf(members.size, 3)
-    val extraCount = members.size - displayCount
+    val extraCount   = members.size - displayCount
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.wrapContentWidth()
     ) {
+        // Stacked avatars box — width = offset*(n-1) + avatarSize
+        val stackWidth = if (displayCount > 0)
+            AVATAR_OFFSET * (displayCount - 1) + AVATAR_SIZE
+        else 0.dp
+
         Box(
             modifier = Modifier
-                .width((displayCount * 14 + 28).dp)
-                .height(28.dp)
+                .width(stackWidth)
+                .height(AVATAR_SIZE)
         ) {
             repeat(displayCount) { index ->
                 Box(
                     modifier = Modifier
-                        .offset(x = (index * 14).dp)
-                        .size(28.dp)
+                        .offset(x = AVATAR_OFFSET * index)
+                        .requiredSize(AVATAR_SIZE)
                         .clip(CircleShape)
-                        .background(AVATAR_COLORS[index % AVATAR_COLORS.size]),
+                        .background(AVATAR_COLORS[index % AVATAR_COLORS.size])
+                        .border(BorderStroke(1.dp, AVATAR_BORDER), CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = members.getOrNull(index)?.avatarInitials ?: "",
-                        fontSize = 10.sp,
-                        fontWeight = FontWeight.Bold,
+                        style = TextStyle(fontSize = 10.sp, fontWeight = FontWeight.Bold),
                         color = Color.White
                     )
                 }
@@ -67,22 +78,21 @@ fun MemberAvatarStack(
         }
 
         if (extraCount > 0) {
-            Spacer(modifier = Modifier.width(4.dp))
+            Spacer(modifier = Modifier.width(1.dp))
             Box(
                 modifier = Modifier
-                    .size(28.dp)
+                    .requiredSize(AVATAR_SIZE)
                     .clip(CircleShape)
                     .background(
-                        if (isSelected) Color.White.copy(alpha = 0.25f)
-                        else Color(0xFFCDD5D8)
-                    ),
+                        if (isSelected) Color.White.copy(alpha = 0.25f) else Color.White
+                    )
+                    .border(BorderStroke(1.dp, AVATAR_BORDER), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = "+$extraCount",
-                    fontSize = 9.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = if (isSelected) Color.White else TextDark
+                    style = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Normal),
+                    color = if (isSelected) Color.White else Color.DarkGray
                 )
             }
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/MemberAvatarStack.kt
@@ -1,0 +1,90 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.ui.theme.TextDark
+
+private val AVATAR_COLORS = listOf(
+    Color(0xFFE8A87C),
+    Color(0xFF7EC8C8),
+    Color(0xFFB8D4E8),
+    Color(0xFFE8C87C),
+    Color(0xFF8CB87C)
+)
+
+@Composable
+fun MemberAvatarStack(
+    members: List<ShareUser>,
+    isSelected: Boolean
+) {
+    val displayCount = minOf(members.size, 3)
+    val extraCount = members.size - displayCount
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.wrapContentWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .width((displayCount * 14 + 28).dp)
+                .height(28.dp)
+        ) {
+            repeat(displayCount) { index ->
+                Box(
+                    modifier = Modifier
+                        .offset(x = (index * 14).dp)
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(AVATAR_COLORS[index % AVATAR_COLORS.size]),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = members.getOrNull(index)?.avatarInitials ?: "",
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                }
+            }
+        }
+
+        if (extraCount > 0) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (isSelected) Color.White.copy(alpha = 0.25f)
+                        else Color(0xFFCDD5D8)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "+$extraCount",
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = if (isSelected) Color.White else TextDark
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareUser
 
-// Figma: card height 68dp, clip RoundedCornerShape(12dp), content offset x=16,y=12
 private val CardShape   = RoundedCornerShape(12.dp)
 private val SubtextColor = Color(0xFF597271)
 private val CloseIconColor = Color(0xFFE05555)
@@ -40,7 +39,6 @@ fun SelectedUserRow(
     user: ShareUser,
     onRemove: () -> Unit
 ) {
-    // Figma: fillMaxWidth, height 68dp, clip 12dp, white bg
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -48,7 +46,6 @@ fun SelectedUserRow(
             .clip(CardShape)
             .background(Color.White)
     ) {
-        // Content: avatar + text, offset x=16, y=12
         Box(
             modifier = Modifier
                 .align(Alignment.TopStart)
@@ -56,13 +53,11 @@ fun SelectedUserRow(
                 .requiredWidth(288.dp)
                 .requiredHeight(44.dp)
         ) {
-            // Avatar circle with initials
             UserAvatar(
                 initials = user.avatarInitials,
                 color = Color(user.avatarColor),
                 size = 40
             )
-            // Text column — offset x=56 from avatar
             Column(
                 verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
                 modifier = Modifier
@@ -89,7 +84,6 @@ fun SelectedUserRow(
             }
         }
 
-        // Close button — Figma: offset x=339, y=20
         Row(
             horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp, Alignment.End),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
@@ -1,12 +1,16 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -17,62 +21,93 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareUser
-import com.oracle.visualize.ui.theme.TextDark
-import com.oracle.visualize.ui.theme.TextGray
 
-private val RemoveRed = Color(0xFFE05555)
+// Figma: card height 68dp, clip RoundedCornerShape(12dp), content offset x=16,y=12
+private val CardShape   = RoundedCornerShape(12.dp)
+private val SubtextColor = Color(0xFF597271)
+private val CloseIconColor = Color(0xFFE05555)
 
 @Composable
 fun SelectedUserRow(
     user: ShareUser,
     onRemove: () -> Unit
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+    // Figma: fillMaxWidth, height 68dp, clip 12dp, white bg
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .shadow(1.dp, RoundedCornerShape(14.dp))
-            .background(Color.White, RoundedCornerShape(14.dp))
-            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .requiredHeight(68.dp)
+            .clip(CardShape)
+            .background(Color.White)
     ) {
-        UserAvatar(
-            initials = user.avatarInitials,
-            color = Color(user.avatarColor),
-            size = 44
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = user.name,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = TextDark
-            )
-            Text(
-                text = user.email,
-                fontSize = 12.sp,
-                color = TextGray,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        IconButton(
-            onClick = onRemove,
-            modifier = Modifier.size(32.dp)
+        // Content: avatar + text, offset x=16, y=12
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .offset(x = 16.dp, y = 12.dp)
+                .requiredWidth(288.dp)
+                .requiredHeight(44.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = "Remove user",
-                tint = RemoveRed,
-                modifier = Modifier.size(16.dp)
+            // Avatar circle with initials
+            UserAvatar(
+                initials = user.avatarInitials,
+                color = Color(user.avatarColor),
+                size = 40
             )
+            // Text column — offset x=56 from avatar
+            Column(
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(x = 56.dp, y = 0.dp)
+                    .requiredWidth(232.dp)
+                    .requiredHeight(44.dp)
+            ) {
+                Text(
+                    text = user.name,
+                    color = Color(0xFF1D1B20),
+                    fontSize = 16.sp,
+                    lineHeight = 1.5.em,
+                    fontWeight = FontWeight.Normal
+                )
+                Text(
+                    text = user.email,
+                    color = SubtextColor,
+                    fontSize = 14.sp,
+                    lineHeight = 1.43.em,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        // Close button — Figma: offset x=339, y=20
+        Row(
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp, Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .offset(x = 339.dp, y = 20.dp)
+        ) {
+            IconButton(
+                onClick = onRemove,
+                modifier = Modifier.requiredSize(24.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Remove user",
+                    tint = CloseIconColor,
+                    modifier = Modifier.requiredSize(16.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/SelectedUserRow.kt
@@ -1,0 +1,78 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+
+private val RemoveRed = Color(0xFFE05555)
+
+@Composable
+fun SelectedUserRow(
+    user: ShareUser,
+    onRemove: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(1.dp, RoundedCornerShape(14.dp))
+            .background(Color.White, RoundedCornerShape(14.dp))
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        UserAvatar(
+            initials = user.avatarInitials,
+            color = Color(user.avatarColor),
+            size = 44
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = user.name,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = TextDark
+            )
+            Text(
+                text = user.email,
+                fontSize = 12.sp,
+                color = TextGray,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        IconButton(
+            onClick = onRemove,
+            modifier = Modifier.size(32.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Remove user",
+                tint = RemoveRed,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
@@ -1,62 +1,95 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
+import androidx.compose.animation.animateColorAsState
+
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.ui.theme.TealPrimary
 import com.oracle.visualize.ui.theme.TextDark
-import com.oracle.visualize.ui.theme.TextGray
 
-private val TealSelected = Color(0xFF3D8C84)
 private val TeamUnselectedBg = Color(0xFFE5ECEB)
+private val SubtextSelected  = Color(0xFFCDE9EA)
+private val SubtextUnselected = Color(0xFF597271)
+
+val ShapeTop    = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp, bottomStart = 5.dp, bottomEnd = 5.dp)
+val ShapeMiddle = RoundedCornerShape(5.dp)
+val ShapeBottom = RoundedCornerShape(topStart = 5.dp, topEnd = 5.dp, bottomStart = 15.dp, bottomEnd = 15.dp)
+val ShapeSingle = RoundedCornerShape(15.dp)
+
+enum class TeamRowPosition { SINGLE, TOP, MIDDLE, BOTTOM }
 
 @Composable
 fun TeamRow(
     team: ShareTeam,
-    onToggle: () -> Unit
+    onToggle: () -> Unit,
+    position: TeamRowPosition = TeamRowPosition.SINGLE
 ) {
-    val bgColor = if (team.isSelected) TealSelected else TeamUnselectedBg
+    val shape = when (position) {
+        TeamRowPosition.TOP    -> ShapeTop
+        TeamRowPosition.MIDDLE -> ShapeMiddle
+        TeamRowPosition.BOTTOM -> ShapeBottom
+        TeamRowPosition.SINGLE -> ShapeSingle
+    }
+
+    val targetBg = if (team.isSelected) TealPrimary else TeamUnselectedBg
+    val animatedBg by animateColorAsState(
+        targetValue = targetBg,
+        animationSpec = tween(200),
+        label = "teamBg"
+    )
     val textColor = if (team.isSelected) Color.White else TextDark
-    val subColor = if (team.isSelected) Color.White.copy(alpha = 0.85f) else TextGray
+    val subColor  = if (team.isSelected) SubtextSelected else SubtextUnselected
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .shadow(if (team.isSelected) 0.dp else 2.dp, RoundedCornerShape(14.dp))
-            .background(bgColor, RoundedCornerShape(14.dp))
-            .clickable { onToggle() }
-            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .clip(shape)
+            .background(animatedBg)
+            .clickable {
+                onToggle() }
+            .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         Column(modifier = Modifier.weight(1f)) {
+            Spacer(modifier = Modifier.height(5.dp))
             Text(
                 text = team.name,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = textColor
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Normal,
+                color = textColor,
+                lineHeight = 24.sp
             )
+            Spacer(modifier = Modifier.height(5.dp))
             Text(
                 text = "${team.memberCount} members",
-                fontSize = 12.sp,
-                color = subColor
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Normal,
+                color = subColor,
+                lineHeight = 20.sp
             )
         }
-        MemberAvatarStack(
-            members = team.members,
-            isSelected = team.isSelected
-        )
+        MemberAvatarStack(members = team.members, isSelected = team.isSelected)
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
@@ -1,0 +1,62 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+
+private val TealSelected = Color(0xFF3D8C84)
+private val TeamUnselectedBg = Color(0xFFE5ECEB)
+
+@Composable
+fun TeamRow(
+    team: ShareTeam,
+    onToggle: () -> Unit
+) {
+    val bgColor = if (team.isSelected) TealSelected else TeamUnselectedBg
+    val textColor = if (team.isSelected) Color.White else TextDark
+    val subColor = if (team.isSelected) Color.White.copy(alpha = 0.85f) else TextGray
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(if (team.isSelected) 0.dp else 2.dp, RoundedCornerShape(14.dp))
+            .background(bgColor, RoundedCornerShape(14.dp))
+            .clickable { onToggle() }
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = team.name,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = textColor
+            )
+            Text(
+                text = "${team.memberCount} members",
+                fontSize = 12.sp,
+                color = subColor
+            )
+        }
+        MemberAvatarStack(
+            members = team.members,
+            isSelected = team.isSelected
+        )
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/TeamRow.kt
@@ -1,23 +1,15 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
 import androidx.compose.animation.animateColorAsState
-
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,12 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.ShareTeam
-import com.oracle.visualize.ui.theme.TealPrimary
-import com.oracle.visualize.ui.theme.TextDark
-
-private val TeamUnselectedBg = Color(0xFFE5ECEB)
-private val SubtextSelected  = Color(0xFFCDE9EA)
-private val SubtextUnselected = Color(0xFF597271)
+import com.oracle.visualize.ui.theme.AppColors
 
 val ShapeTop    = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp, bottomStart = 5.dp, bottomEnd = 5.dp)
 val ShapeMiddle = RoundedCornerShape(5.dp)
@@ -43,6 +30,7 @@ enum class TeamRowPosition { SINGLE, TOP, MIDDLE, BOTTOM }
 @Composable
 fun TeamRow(
     team: ShareTeam,
+    isSelected: Boolean,        // Selection state passed from UI layer, not from entity
     onToggle: () -> Unit,
     position: TeamRowPosition = TeamRowPosition.SINGLE
 ) {
@@ -53,14 +41,10 @@ fun TeamRow(
         TeamRowPosition.SINGLE -> ShapeSingle
     }
 
-    val targetBg = if (team.isSelected) TealPrimary else TeamUnselectedBg
-    val animatedBg by animateColorAsState(
-        targetValue = targetBg,
-        animationSpec = tween(200),
-        label = "teamBg"
-    )
-    val textColor = if (team.isSelected) Color.White else TextDark
-    val subColor  = if (team.isSelected) SubtextSelected else SubtextUnselected
+    val targetBg = if (isSelected) AppColors.teamSelectedBg else AppColors.teamUnselectedBg
+    val animatedBg by animateColorAsState(targetValue = targetBg, animationSpec = tween(200), label = "teamBg")
+    val textColor = if (isSelected) Color.White else AppColors.textDark
+    val subColor  = if (isSelected) AppColors.subtextSelected else AppColors.subtextUnselected
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -68,28 +52,15 @@ fun TeamRow(
             .fillMaxWidth()
             .clip(shape)
             .background(animatedBg)
-            .clickable {
-                onToggle() }
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clickable { onToggle() }
+
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Spacer(modifier = Modifier.height(5.dp))
-            Text(
-                text = team.name,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Normal,
-                color = textColor,
-                lineHeight = 24.sp
-            )
+            Text(text = team.name, fontSize = 16.sp, fontWeight = FontWeight.Normal, color = textColor, lineHeight = 24.sp)
             Spacer(modifier = Modifier.height(5.dp))
-            Text(
-                text = "${team.memberCount} members",
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Normal,
-                color = subColor,
-                lineHeight = 20.sp
-            )
+            Text(text = "${team.memberCount} members", fontSize = 14.sp, color = subColor, lineHeight = 20.sp)
         }
-        MemberAvatarStack(members = team.members, isSelected = team.isSelected)
+        MemberAvatarStack(members = team.members, isSelected = isSelected)
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
@@ -1,0 +1,81 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.oracle.visualize.ui.theme.TextDark
+import com.oracle.visualize.ui.theme.TextGray
+import com.oracle.visualize.ui.theme.TealPrimary
+
+@Composable
+fun UnsavedChangesDialog(
+    onDismiss: () -> Unit,
+    onConfirmLeave: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .background(Color.White, RoundedCornerShape(20.dp))
+                .padding(horizontal = 24.dp, vertical = 28.dp)
+        ) {
+            Text(
+                text = "Unsaved Changes",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Normal,
+                color = TextDark
+            )
+            Spacer(modifier = Modifier.height(14.dp))
+            Text(
+                text = "You have unsaved changes. Are you sure you want to leave?",
+                fontSize = 14.sp,
+                color = TextGray,
+                lineHeight = 21.sp
+            )
+            Spacer(modifier = Modifier.height(28.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(
+                        text = "Cancel",
+                        color = TextGray,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 15.sp
+                    )
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                TextButton(onClick = onConfirmLeave) {
+                    Text(
+                        text = "Share",
+                        color = TealPrimary,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UnsavedChangesDialog.kt
@@ -1,13 +1,15 @@
 package com.oracle.visualize.presentation.screens.ShareScreen.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -17,12 +19,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.oracle.visualize.ui.theme.TextDark
-import com.oracle.visualize.ui.theme.TextGray
 import com.oracle.visualize.ui.theme.TealPrimary
+
+// Figma AC-70: overlay Color(0xFF1A2F3F) alpha 0.2, dialog offset x=50, width=312, corners=28dp
+private val OverlayColor   = Color(0xFF1A2F3F).copy(alpha = 0.2f)
+private val DialogBg       = Color.White
+private val TitleColor     = Color(0xFF1D1B20)
+private val BodyColor      = Color(0xFF49454F)
 
 @Composable
 fun UnsavedChangesDialog(
@@ -33,47 +40,66 @@ fun UnsavedChangesDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Column(
+        Box(
             modifier = Modifier
-                .fillMaxWidth(0.9f)
-                .background(Color.White, RoundedCornerShape(20.dp))
-                .padding(horizontal = 24.dp, vertical = 28.dp)
+                .fillMaxSize()
+                .background(OverlayColor),
+            contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = "Unsaved Changes",
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Normal,
-                color = TextDark
-            )
-            Spacer(modifier = Modifier.height(14.dp))
-            Text(
-                text = "You have unsaved changes. Are you sure you want to leave?",
-                fontSize = 14.sp,
-                color = TextGray,
-                lineHeight = 21.sp
-            )
-            Spacer(modifier = Modifier.height(28.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically
+            Column(
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier
+                    .fillMaxWidth(0.76f)
+                    .background(DialogBg, RoundedCornerShape(28.dp))
             ) {
-                TextButton(onClick = onDismiss) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 24.dp, top = 24.dp)
+                ) {
                     Text(
-                        text = "Cancel",
-                        color = TextGray,
-                        fontWeight = FontWeight.Medium,
-                        fontSize = 15.sp
+                        text = "Unsaved Changes",
+                        color = TitleColor,
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Normal,
+                        lineHeight = 1.33.em
+                    )
+                    Text(
+                        text = "You have unsaved changes. Are you sure you want to leave?",
+                        color = BodyColor,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Normal,
+                        lineHeight = 1.43.em
                     )
                 }
-                Spacer(modifier = Modifier.width(16.dp))
-                TextButton(onClick = onConfirmLeave) {
-                    Text(
-                        text = "Share",
-                        color = TealPrimary,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 15.sp
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(
+                        start = 8.dp, end = 24.dp,
+                        top = 20.dp, bottom = 20.dp
                     )
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(
+                            text = "Cancel",
+                            color = TealPrimary,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            lineHeight = 1.43.em
+                        )
+                    }
+                    TextButton(onClick = onConfirmLeave) {
+                        Text(
+                            text = "Share",
+                            color = TealPrimary,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            lineHeight = 1.43.em
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UserAvatar.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/ShareScreen/components/UserAvatar.kt
@@ -1,0 +1,37 @@
+package com.oracle.visualize.presentation.screens.ShareScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun UserAvatar(
+    initials: String,
+    color: Color,
+    size: Int = 38
+) {
+    Box(
+        modifier = Modifier
+            .size(size.dp)
+            .clip(CircleShape)
+            .background(color),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            fontSize = (size * 0.37f).sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/ui/theme/AppColors.kt
+++ b/app/src/main/java/com/oracle/visualize/ui/theme/AppColors.kt
@@ -1,0 +1,119 @@
+package com.oracle.visualize.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+// ─── Color set ────────────────────────────────────────────────────────────────
+
+data class VisualizeColors(
+    val screenBackground: Color,
+    val topBarColor: Color,
+    val tealPrimary: Color,
+    val tealLight: Color,
+    val textDark: Color,
+    val textGray: Color,
+    val borderGray: Color,
+    val orangeButton: Color,
+    val navBarBackground: Color,
+    val navBarSelected: Color,
+    val navBarIconUnselected: Color,
+    val navBarIconSelected: Color,
+    val errorRed: Color,
+    val errorBackground: Color,
+    val cardBackground: Color,
+    val teamUnselectedBg: Color,
+    val teamSelectedBg: Color,
+    // Share screen
+    val searchBarBg: Color,
+    val avatarBorder: Color,
+    val dialogBg: Color,
+    val dialogBody: Color,
+    val subtextSelected: Color,
+    val subtextUnselected: Color,
+    val sectionTitle: Color,
+    // Feed screen
+    val feedCardBg: Color,
+    val feedCardBorder: Color,
+    val textAccent: Color,   // meta info color (author, date)
+    val textMuted: Color,    // placeholder, small info
+    val isDark: Boolean
+)
+
+// ─── Light palette ────────────────────────────────────────────────────────────
+
+val LightColors = VisualizeColors(
+    screenBackground     = LightScreenBackground,
+    topBarColor          = LightTopBarColor,
+    tealPrimary          = LightTealPrimary,
+    tealLight            = LightTealLight,
+    textDark             = LightTextDark,
+    textGray             = LightTextGray,
+    borderGray           = LightBorderGray,
+    orangeButton         = LightOrangeButton,
+    navBarBackground     = LightNavBarBackground,
+    navBarSelected       = LightNavBarSelected,
+    navBarIconUnselected = LightNavBarIconUnselected,
+    navBarIconSelected   = LightNavBarIconSelected,
+    errorRed             = LightErrorRed,
+    errorBackground      = LightErrorBackground,
+    cardBackground       = LightCardBackground,
+    teamUnselectedBg     = LightTeamUnselectedBg,
+    teamSelectedBg       = LightTeamSelectedBg,
+    searchBarBg          = LightSearchBarBg,
+    avatarBorder         = LightAvatarBorder,
+    dialogBg             = LightDialogBg,
+    dialogBody           = LightDialogBody,
+    subtextSelected      = LightSubtextSelected,
+    subtextUnselected    = LightSubtextUnselected,
+    sectionTitle         = LightTextDark,
+    feedCardBg           = LightCardBackground,
+    feedCardBorder       = LightBorderGray,
+    textAccent           = LightTealPrimary,
+    textMuted            = Color(0xFF7FA9A9),
+    isDark               = false
+)
+
+// ─── Dark palette (Figma exact) ───────────────────────────────────────────────
+
+val DarkColors = VisualizeColors(
+    screenBackground     = DarkScreenBackground,
+    topBarColor          = DarkTopBarColor,
+    tealPrimary          = DarkTealPrimary,
+    tealLight            = DarkTealLight,
+    textDark             = DarkTextDark,
+    textGray             = DarkTextGray,
+    borderGray           = DarkBorderGray,
+    orangeButton         = DarkOrangeButton,
+    navBarBackground     = DarkNavBarBackground,
+    navBarSelected       = DarkNavBarSelected,
+    navBarIconUnselected = DarkNavBarIconUnselected,
+    navBarIconSelected   = DarkNavBarIconSelected,
+    errorRed             = DarkErrorRed,
+    errorBackground      = DarkErrorBackground,
+    cardBackground       = DarkCardBackground,
+    teamUnselectedBg     = DarkTeamUnselectedBg,
+    teamSelectedBg       = DarkTeamSelectedBg,
+    searchBarBg          = DarkSearchBarBg,
+    avatarBorder         = DarkAvatarBorder,
+    dialogBg             = DarkDialogBg,
+    dialogBody           = DarkDialogBody,
+    subtextSelected      = DarkSubtextSelected,
+    subtextUnselected    = DarkSubtextUnselected,
+    sectionTitle         = DarkSectionTitle,
+    feedCardBg           = DarkCardBackground,
+    feedCardBorder       = DarkFeedCardBorder,
+    textAccent           = DarkTextAccent,
+    textMuted            = DarkTextMuted,
+    isDark               = true
+)
+
+// ─── CompositionLocal ─────────────────────────────────────────────────────────
+
+val LocalAppColors = compositionLocalOf<VisualizeColors> { LightColors }
+
+val AppColors: VisualizeColors
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalAppColors.current

--- a/app/src/main/java/com/oracle/visualize/ui/theme/Color.kt
+++ b/app/src/main/java/com/oracle/visualize/ui/theme/Color.kt
@@ -20,11 +20,16 @@ val LightGreen = Color(0xFFCDE9EA)
 val ScreenBackground = Color(0xFFF5F4F2)
 val TopBarColor = Color(0xFFCDE9EA)
 val TealPrimary = Color(0xFF34797C)
-val TealLight = Color(0xFFCDE9EA) // Use TopBar color as the light variant
+val TealLight = Color(0xFFCDE9EA)
 val TextDark = Color(0xFF13212C)
 val TextGray = Color(0xFF323232)
 val BorderGray = Color(0xFFCCCCCC)
 val OrangeButton = Color(0xFFE69138)
+
+// Share screen
+val TealSelected = Color(0xFF3D8C84)
+val TeamUnselectedBg = Color(0xFFE5ECEB)
+val RemoveRed = Color(0xFFE05555)
 
 // Error states
 val ErrorRed = Color(0xFFD32F2F)
@@ -35,14 +40,3 @@ val NavBarBackground = Color(0xFFCDE9EA)
 val NavBarSelected = Color(0xFF34797C)
 val NavBarIconUnselected = Color(0xFF4A454E)
 val NavBarIconSelected = Color(0xFFFFFFFF)
-
-/*
-the colors of the various elements of a navigation item.
-Params:
-selectedIconColor - the color to use for the icon when the item is selected.
-selectedTextColor - the color to use for the text label when the item is selected.
-selectedIndicatorColor - the color to use for the indicator when the item is selected.
-unselectedIconColor - the color to use for the icon when the item is unselected.
-unselectedTextColor - the color to use for the text label when the item is unselected.
-disabledIconColor - the color to use for the icon when the item is disabled.
-disabledTextColor - the color to use for the text label when the item is disabled.*/

--- a/app/src/main/java/com/oracle/visualize/ui/theme/Color.kt
+++ b/app/src/main/java/com/oracle/visualize/ui/theme/Color.kt
@@ -2,41 +2,152 @@ package com.oracle.visualize.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
+// ─── Base palette (raw colors — do not use directly in composables) ───────────
+
+// Teal family
+val Teal10  = Color(0xFF002021)
+val Teal20  = Color(0xFF00373A)
+val Teal30  = Color(0xFF004F54)
+val Teal40  = Color(0xFF34797C)   // Primary — Figma TealPrimary light
+val Teal80  = Color(0xFFA9C8C4)
+val Teal90  = Color(0xFFCDE9EA)   // Lightest — Figma TopBarColor light
+val Teal95  = Color(0xFFE6F4F4)
+
+// Orange family
+val Orange40 = Color(0xFFE69138)  // Figma OrangeButton light
+val Orange80 = Color(0xFFFFB74D)
+
+// Neutral family
+val Neutral10  = Color(0xFF13212C)
+val Neutral30  = Color(0xFF323232)
+val Neutral80  = Color(0xFFCCCCCC)
+val Neutral95  = Color(0xFFF5F4F2)
+val NeutralWhite = Color(0xFFFFFFFF)
+
+// Error family
+val Error40  = Color(0xFFD32F2F)
+val Error90  = Color(0xFFFFEBEE)
+val Error80  = Color(0xFFEF9A9A)
+
+// ─── Figma Dark Mode exact values (extracted from Figma source code) ──────────
+// Screen backgrounds
+val FigmaDarkBg         = Color(0xFF282520)   // All screens background
+val FigmaDarkTopBar     = Color(0xFF2A5152)   // Top bar + nav bar + dialog bg
+val FigmaDarkNavBar     = Color(0xFF2C5354)   // Bottom navbar (Feed screen)
+val FigmaDarkNavBarAlt  = Color(0xFF2A5152)   // Bottom navbar (Create/Share)
+
+// Surface / card colors
+val FigmaDarkCard       = Color(0xFF3D504D)   // Feed cards
+val FigmaDarkCardBorder = Color(0xFF80A7A1)   // Feed card selected border
+val FigmaDarkTeamCard   = Color(0xFF415351)   // Team rows unselected
+val FigmaDarkSurface2   = Color(0xFF1E1E1E)   // Create screen upload area bg
+
+// Selection / indicator colors
+val FigmaDarkSelected   = Color(0xFF244546)   // NavBar selected pill, team selected subtext
+val FigmaDarkTeal       = Color(0xFF34797C)   // Selected team card bg, teal primary dark
+
+// Text colors
+val FigmaDarkTextPrimary  = Color(0xFFFFFDFD)  // Main titles and body text
+val FigmaDarkTextSecond   = Color(0xFFEBE5E5)  // Section titles ("My Teams")
+val FigmaDarkTextSub      = Color(0xFF597271)  // Subtexts, descriptions
+val FigmaDarkTextMuted    = Color(0xFFBEDBDC)  // Small info text, search placeholder
+val FigmaDarkTextAccent   = Color(0xFF8AC1C4)  // Feed meta info, icon tints
+val FigmaDarkTextLabel    = Color(0xFFD9D9D9)  // NavBar labels
+
+// Avatar / border
+val FigmaDarkAvatarBorder = Color(0xFF244546)  // Avatar circle borders dark
+val FigmaDarkBorder       = Color(0xFFBEDBDC)  // Upload box border
+
+// Dialog
+val FigmaDarkDialogBg     = Color(0xFF2A5152)  // UnsavedChanges dialog background
+val FigmaDarkDialogBody   = Color(0xFFD9D9D9)  // Dialog body text
+
+// Error / destructive
+val FigmaDarkErrorText    = Color(0xFFD55555)  // Delete for everyone text
+
+// ─── Light semantic tokens ────────────────────────────────────────────────────
+
+val LightScreenBackground     = Neutral95
+val LightTopBarColor          = Teal90
+val LightTealPrimary          = Teal40
+val LightTealLight            = Teal90
+val LightTextDark             = Neutral10
+val LightTextGray             = Neutral30
+val LightBorderGray           = Neutral80
+val LightOrangeButton         = Orange40
+val LightNavBarBackground     = Teal90
+val LightNavBarSelected       = Teal40
+val LightNavBarIconUnselected = Color(0xFF4A454E)
+val LightNavBarIconSelected   = NeutralWhite
+val LightErrorRed             = Error40
+val LightErrorBackground      = Error90
+val LightCardBackground       = NeutralWhite
+val LightTeamUnselectedBg     = Color(0xFFE5ECEB)
+val LightTeamSelectedBg       = Teal40
+val LightSearchBarBg          = Color(0xFFF5F5F5)
+val LightAvatarBorder         = Color(0xFFE6EDEC)
+val LightDialogBg             = NeutralWhite
+val LightDialogBody           = Color(0xFF49454F)
+val LightSubtextSelected      = Color(0xFFCDE9EA)
+val LightSubtextUnselected    = Color(0xFF597271)
+
+// ─── Dark semantic tokens (Figma exact) ──────────────────────────────────────
+
+val DarkScreenBackground     = FigmaDarkBg
+val DarkTopBarColor          = FigmaDarkTopBar
+val DarkTealPrimary          = FigmaDarkTeal
+val DarkTealLight            = FigmaDarkSelected
+val DarkTextDark             = FigmaDarkTextPrimary
+val DarkTextGray             = FigmaDarkTextSub
+val DarkBorderGray           = FigmaDarkAvatarBorder
+val DarkOrangeButton         = Orange40              // Figma keeps orange unchanged
+val DarkNavBarBackground     = FigmaDarkNavBar
+val DarkNavBarSelected       = FigmaDarkSelected
+val DarkNavBarIconUnselected = FigmaDarkTextLabel
+val DarkNavBarIconSelected   = FigmaDarkTextPrimary
+val DarkErrorRed             = FigmaDarkErrorText
+val DarkErrorBackground      = Color(0xFF4D1F1F)
+val DarkCardBackground       = FigmaDarkCard
+val DarkTeamUnselectedBg     = FigmaDarkTeamCard
+val DarkTeamSelectedBg       = FigmaDarkTeal
+val DarkSearchBarBg          = FigmaDarkSurface2
+val DarkAvatarBorder         = FigmaDarkAvatarBorder
+val DarkDialogBg             = FigmaDarkDialogBg
+val DarkDialogBody           = FigmaDarkDialogBody
+val DarkSubtextSelected      = FigmaDarkSelected
+val DarkSubtextUnselected    = FigmaDarkTextSub
+val DarkSectionTitle         = FigmaDarkTextSecond
+val DarkFeedCardBorder       = FigmaDarkCardBorder
+val DarkTextAccent           = FigmaDarkTextAccent
+val DarkTextMuted            = FigmaDarkTextMuted
+
+// ─── Legacy aliases (backward compatibility — screens not yet migrated) ───────
+
+val ScreenBackground     = LightScreenBackground
+val TopBarColor          = LightTopBarColor
+val TealPrimary          = LightTealPrimary
+val TealLight            = LightTealLight
+val TextDark             = LightTextDark
+val TextGray             = LightTextGray
+val BorderGray           = LightBorderGray
+val OrangeButton         = LightOrangeButton
+val NavBarBackground     = LightNavBarBackground
+val NavBarSelected       = LightNavBarSelected
+val NavBarIconUnselected = LightNavBarIconUnselected
+val NavBarIconSelected   = LightNavBarIconSelected
+val ErrorRed             = LightErrorRed
+val ErrorBackground      = LightErrorBackground
+
+// Feed (legacy)
+val StrongGreen   = Teal80
+val StrongerGreen = Teal40
+val Green         = Color(0xFFE6EDEC)
+val LightGreen    = Teal90
+
+// Material baseline (legacy)
+val Purple80     = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
+val Pink80       = Color(0xFFEFB8C8)
+val Purple40     = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
-
-// Feed
-val StrongGreen = Color(0xFFA9C8C4)
-val StrongerGreen = Color(0xFF34797C)
-val Green = Color(0xFFE6EDEC)
-val LightGreen = Color(0xFFCDE9EA)
-
-// Official Figma Colors
-val ScreenBackground = Color(0xFFF5F4F2)
-val TopBarColor = Color(0xFFCDE9EA)
-val TealPrimary = Color(0xFF34797C)
-val TealLight = Color(0xFFCDE9EA)
-val TextDark = Color(0xFF13212C)
-val TextGray = Color(0xFF323232)
-val BorderGray = Color(0xFFCCCCCC)
-val OrangeButton = Color(0xFFE69138)
-
-// Share screen
-val TealSelected = Color(0xFF3D8C84)
-val TeamUnselectedBg = Color(0xFFE5ECEB)
-val RemoveRed = Color(0xFFE05555)
-
-// Error states
-val ErrorRed = Color(0xFFD32F2F)
-val ErrorBackground = Color(0xFFFFEBEE)
-
-// Navigation
-val NavBarBackground = Color(0xFFCDE9EA)
-val NavBarSelected = Color(0xFF34797C)
-val NavBarIconUnselected = Color(0xFF4A454E)
-val NavBarIconSelected = Color(0xFFFFFFFF)
+val Pink40       = Color(0xFF7D5260)

--- a/app/src/main/java/com/oracle/visualize/ui/theme/Theme.kt
+++ b/app/src/main/java/com/oracle/visualize/ui/theme/Theme.kt
@@ -8,47 +8,69 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 
+// ─── Material3 schemes (Figma exact dark values) ──────────────────────────────
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80,
-    surface = StrongGreen
+private val M3DarkColorScheme = darkColorScheme(
+    primary              = FigmaDarkTeal,
+    onPrimary            = FigmaDarkTextPrimary,
+    primaryContainer     = FigmaDarkSelected,
+    secondary            = FigmaDarkTeal,
+    onSecondary          = FigmaDarkTextPrimary,
+    secondaryContainer   = FigmaDarkSelected,
+    onSecondaryContainer = FigmaDarkTextPrimary,
+    tertiary             = Orange40,
+    background           = FigmaDarkBg,
+    surface              = FigmaDarkCard,
+    surfaceContainer     = FigmaDarkNavBar,
+    onBackground         = FigmaDarkTextPrimary,
+    onSurface            = FigmaDarkTextLabel,
+    error                = FigmaDarkErrorText
 )
 
-private val LightColorScheme = lightColorScheme(
-    primary = LightGreen,
-    secondary = Green,
-    tertiary = StrongerGreen,
-    surface = StrongGreen,
-    surfaceContainer = NavBarBackground,
-    secondaryContainer = NavBarSelected,
-    onSecondaryContainer = NavBarIconSelected,
-    onSurface = NavBarIconUnselected,
-    )
+private val M3LightColorScheme = lightColorScheme(
+    primary              = LightTealPrimary,
+    onPrimary            = LightNavBarIconSelected,
+    primaryContainer     = LightTealLight,
+    secondary            = LightTealPrimary,
+    onSecondary          = LightNavBarIconSelected,
+    secondaryContainer   = LightNavBarSelected,
+    onSecondaryContainer = LightNavBarIconSelected,
+    tertiary             = LightOrangeButton,
+    background           = LightScreenBackground,
+    surface              = LightCardBackground,
+    surfaceContainer     = LightNavBarBackground,
+    onBackground         = LightTextDark,
+    onSurface            = LightNavBarIconUnselected,
+    error                = LightErrorRed
+)
+
+// ─── VisualizeTheme ───────────────────────────────────────────────────────────
 
 @Composable
 fun VisualizeTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
+    val appColors = if (darkTheme) DarkColors else LightColors
+
+    val m3ColorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+        darkTheme -> M3DarkColorScheme
+        else      -> M3LightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    CompositionLocalProvider(LocalAppColors provides appColors) {
+        MaterialTheme(
+            colorScheme = m3ColorScheme,
+            typography  = Typography,
+            content     = content
+        )
+    }
 }


### PR DESCRIPTION
Files changed:
- ShareTeam.kt: removed isSelected from the domain entity. Selection is
  UI state and has no place in the business model
- ShareUiState.kt: new file in presentation layer following the
  CreateUiState sealed interface pattern. Replaces ShareAndPostState
  which was incorrectly placed in domain/models. States Loading,
  Content and Error. selectedTeamIds added as Set<String> to Content
- ShareUiEvent.kt: new sealed interface with all possible screen events.
  Replaces the 9+ individual lambda parameters in ShareAndPostContent
- ShareAndPostViewModel.kt: removed hardcoded mock data. Data now
  received via loadData() so the ViewModel is ready for a real
  Repository when available. hasChanges computed internally via
  computeHasChanges() so the View stays dumb
- ShareAndPostView.kt: migrated to onEvent pattern using ShareUiEvent.
  hasChanges logic removed from Composable. TeamRow now receives
  isSelected from selectedTeamIds in the state, not from the entity.
  Added Loading and Error state handling
- ShareMockData.kt: mock data moved outside the ViewModel and passed
  via LaunchedEffect as if it came from a data source
- TeamRow.kt: receives isSelected as explicit parameter instead of
  reading team.isSelected from the entity

Problem:
ShareAndPostState was in domain/models when it belongs to the
presentation layer. ShareTeam had isSelected as an entity property
when it is UI state. ShareAndPostContent had 9+ lambda parameters
and contained business logic (hasChanges) that belonged in the
ViewModel. Mock data was hardcoded inside the ViewModel.

Solution:
State moved to presentation layer as a sealed interface. isSelected
removed from entity and tracked as selectedTeamIds in UI state.
Single onEvent callback replaces all lambdas. ViewModel now owns
hasChanges logic. Mock data separated and injected via loadData()
keeping the ViewModel clean for real data integration.