### PR TITLE
Change viz management to use JetPack Navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.material.icons.extended)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.navigation.compose)        // ← add
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -57,8 +60,6 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(platform("com.google.firebase:firebase-bom:34.11.0"))
     implementation("com.google.firebase:firebase-analytics")
     implementation("androidx.compose.material:material-icons-core:1.7.8")

--- a/app/src/main/java/com/oracle/visualize/domain/models/NavRoutes.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/NavRoutes.kt
@@ -1,13 +1,10 @@
 package com.oracle.visualize.domain.models
 
 sealed class NavRoutes(val route: String) {
-    object Feed : NavRoutes("feed")
+    object Feed          : NavRoutes("feed")
     object Notifications : NavRoutes("notifications")
-
-    object Profile : NavRoutes("profile")
-
-    object Teams : NavRoutes("teams")
-
-    object Create : NavRoutes("create")
-
+    object Profile       : NavRoutes("profile")
+    object Teams         : NavRoutes("teams")
+    object Create        : NavRoutes("create")
+    //object Share         : NavRoutes("share")
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/components/BottomNavBar.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/BottomNavBar.kt
@@ -7,39 +7,48 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import com.oracle.visualize.domain.models.NavItem
 
 @Composable
 fun BottomNavBar(
     navItems: List<NavItem>,
-    selectedIndex: Int,
-    onItemSelected: (Int) -> Unit
+    navController: NavController  // NavController replaces selectedIndex + onItemSelected
 ) {
+    // Observe current back stack to highlight the correct tab
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
 
     NavigationBar {
-        navItems.forEachIndexed { index, item ->
+        navItems.forEach { item ->
             NavigationBarItem(
-                selected = selectedIndex == index,
-                onClick = { onItemSelected(index) },
+                selected = currentRoute == item.route,
+                onClick = {
+                    navController.navigate(item.route) {
+                        // Pop up to the start destination to avoid stacking screens
+                        popUpTo(navController.graph.startDestinationId) {
+                            saveState = true
+                        }
+                        // Avoid duplicate copies of the same destination
+                        launchSingleTop = true
+                        // Restore state when navigating back to a tab
+                        restoreState = true
+                    }
+                },
                 icon = {
                     BadgedBox(
                         badge = {
                             if (item.badgeCount > 0) {
-                                Badge {
-                                    Text(text = item.badgeCount.toString())
-                                }
+                                Badge { Text(text = item.badgeCount.toString()) }
                             }
                         }
                     ) {
-                        Icon(
-                            imageVector = item.icon,
-                            contentDescription = item.label
-                        )
+                        Icon(imageVector = item.icon, contentDescription = item.label)
                     }
                 },
-                label = {
-                    Text(text = item.label)
-                }
+                label = { Text(text = item.label) }
             )
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainView.kt
@@ -6,54 +6,95 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.oracle.visualize.presentation.components.BottomNavBar
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 import com.oracle.visualize.domain.models.NavRoutes
+import com.oracle.visualize.presentation.components.BottomNavBar
+import com.oracle.visualize.presentation.screens.CreateScreen.CreatePage
 import com.oracle.visualize.presentation.screens.FeedScreen.FeedPage
 import com.oracle.visualize.presentation.screens.NotificationScreen.NotificationPage
-import com.oracle.visualize.presentation.screens.CreateScreen.CreatePage
-import com.oracle.visualize.ui.theme.ScreenBackground
+
+
+// Bottom nav destinations — screens outside this list hide the nav bar
+private val bottomNavRoutes = setOf(
+    NavRoutes.Feed.route,
+    NavRoutes.Create.route,
+    NavRoutes.Notifications.route,
+    NavRoutes.Teams.route,
+    NavRoutes.Profile.route
+)
 
 @Composable
 fun MainScreen(
-    viewModel: MainViewModel = viewModel()
+    viewModel: MainViewModel = viewModel(),
+    onToggleTheme: () -> Unit = {},
+    isDarkMode: Boolean = false
 ) {
-    //We obtain the state from View
-    val currentRoute by viewModel.currentRoute.collectAsStateWithLifecycle()
-    val selectedIndex by viewModel.selectedIndex.collectAsStateWithLifecycle()
+    val navController = rememberNavController()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
+
+    // Only show bottom nav on main tab destinations
+    val showBottomBar = currentRoute in bottomNavRoutes
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         bottomBar = {
-            BottomNavBar(
-                navItems = viewModel.navItems,
-                selectedIndex = selectedIndex,
-                onItemSelected = viewModel::onNavItemSelected //Update the state
-
-            )
-        },
-        containerColor = ScreenBackground
+            if (showBottomBar) {
+                BottomNavBar(
+                    navItems = viewModel.navItems,
+                    navController = navController
+                )
+            }
+        }
     ) { innerPadding ->
-        ContentScreen(
-            modifier = Modifier.padding(innerPadding),
-            currentRoute = currentRoute //Update the screen type
+        AppNavHost(
+            navController = navController,
+            modifier = Modifier.padding(innerPadding)
         )
     }
 }
 
-
-
+// ─── NavHost ──────────────────────────────────────────────────────────────────
 
 @Composable
-fun ContentScreen(
-    modifier: Modifier = Modifier,
-    currentRoute: String
+fun AppNavHost(
+    navController: NavHostController,
+    modifier: Modifier = Modifier
 ) {
-    when (currentRoute) {
-        NavRoutes.Feed.route -> FeedPage(modifier = modifier)
-        NavRoutes.Notifications.route -> NotificationPage(modifier = modifier)
-        NavRoutes.Create.route -> CreatePage(modifier = modifier)
-        // Add other routes as they are implemented
+    NavHost(
+        navController = navController,
+        startDestination = NavRoutes.Feed.route,
+        modifier = modifier
+    ) {
+        composable(NavRoutes.Feed.route) {
+            FeedPage(modifier = Modifier.fillMaxSize())
+        }
+
+        composable(NavRoutes.Create.route) {
+            CreatePage(modifier = Modifier.fillMaxSize())
+        }
+
+        composable(NavRoutes.Notifications.route) {
+            NotificationPage(modifier = Modifier.fillMaxSize())
+        }
+
+        /* Share screen — no bottom bar, navigates back to Feed
+        composable(NavRoutes.Share.route) {
+                // TODO: Add TeamsPage when implemented
+        }*/
+
+        // Teams and Profile — placeholders until screens are implemented
+        composable(NavRoutes.Teams.route) {
+            // TODO: Add TeamsPage when implemented
+        }
+
+        composable(NavRoutes.Profile.route) {
+            // TODO: Add ProfilePage when implemented
+        }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/MainScreen/MainViewModel.kt
@@ -9,52 +9,36 @@ import androidx.compose.material.icons.filled.Person
 import androidx.lifecycle.ViewModel
 import com.oracle.visualize.domain.models.NavItem
 import com.oracle.visualize.domain.models.NavRoutes
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 class MainViewModel : ViewModel() {
 
-    //State
-    private val route = MutableStateFlow(NavRoutes.Feed.route)
-    private val index = MutableStateFlow(2)
-
-
-    //SetState
-    val currentRoute: StateFlow<String> = route.asStateFlow()
-    val selectedIndex: StateFlow<Int> = index.asStateFlow()
-
+    // NavController owns navigation state — ViewModel only defines the nav items
     val navItems = listOf(
         NavItem(
             label = "Create",
-            icon = Icons.Default.Add,
+            icon  = Icons.Default.Add,
             route = NavRoutes.Create.route
         ),
         NavItem(
             label = "Teams",
-            icon = Icons.Default.Groups,
+            icon  = Icons.Default.Groups,
             route = NavRoutes.Teams.route
         ),
         NavItem(
             label = "Feed",
-            icon = Icons.Default.Home,
+            icon  = Icons.Default.Home,
             route = NavRoutes.Feed.route
         ),
         NavItem(
             label = "Notifications",
-            icon = Icons.Default.Notifications,
+            icon  = Icons.Default.Notifications,
             badgeCount = 5,
             route = NavRoutes.Notifications.route
         ),
         NavItem(
             label = "Profile",
-            icon = Icons.Default.Person,
+            icon  = Icons.Default.Person,
             route = NavRoutes.Profile.route
         )
     )
-
-    fun onNavItemSelected(i: Int) {
-        index.value = i
-        route.value = navItems[i].route
-    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ activityCompose = "1.13.0"
 kotlin = "2.2.10"
 composeBom = "2026.02.01"
 composeIcons = "1.7.8"
+navigationCompose = "2.9.0"   # ← add
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,8 +29,8 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }  # ← add
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-


### PR DESCRIPTION
Change viz management to use JetPack Navigation

Files changed:
- libs.versions.toml + build.gradle.kts: added
  androidx.navigation:navigation-compose:2.9.0 to version catalog
  and module dependencies
- NavRoutes.kt: added Share as a new route. No structural changes
- BottomNavBar.kt: removed selectedIndex: Int and onItemSelected:
  (Int) -> Unit parameters. Now receives NavController directly and
  uses currentBackStackEntryAsState() to detect the active route.
  Tab navigation uses popUpTo + saveState + restoreState following
  official Android guidelines to preserve each tab's state
- MainViewModel.kt: removed currentRoute: StateFlow<String>,
  selectedIndex: StateFlow<Int> and onNavItemSelected(). ViewModel
  now only defines navItems
- MainView.kt: replaced manual when (currentRoute) with a NavHost
  using composable() per destination. Added showBottomBar to hide
  the navbar on detail screens . rememberNavController()
  creates the controller passed to both NavHost and BottomNavBar.
  navigateUp() handles back navigation from Share correctly

Problem:
Navigation state was split between MainViewModel and the composables,
with selectedIndex and currentRoute living in the ViewModel and manual
when (currentRoute) blocks handling destination rendering. BottomNavBar
depended on index-based selection with no awareness of the back stack,
causing state loss when switching tabs and incorrect behavior when
navigating to detail screens.

Solution:
NavController is now the single source of truth for navigation state.
NavHost replaces the manual when block. BottomNavBar reads the active
route from currentBackStackEntryAsState() and navigates using
popUpTo + saveState + restoreState as recommended by the official
Android Navigation guidelines. ViewModel cleaned up by removing all
navigation state that no longer belongs there.