### PR TITLE
Fix: update upload validation and UI labels

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/com/oracle/visualize/domain/usecases/ValidateDatasetUseCase.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/usecases/ValidateDatasetUseCase.kt
@@ -7,12 +7,20 @@ import java.util.Locale
  * Use case to validate if a dataset file has a supported format (.csv or .xlsx).
  */
 class ValidateDatasetUseCase {
-    operator fun invoke(fileName: String): Result<Unit> {
+    operator fun invoke(fileName: String, fileSizeBytes: Long): Result<Unit> {
         val extension = fileName.substringAfterLast(".", "").lowercase(Locale.ROOT)
-        return if (extension == "csv" || extension == "xlsx") {
-            Result.success(Unit)
-        } else {
-            Result.failure(IllegalArgumentException("Please upload a .xlsx or .csv file to continue."))
+        val maxSizeBytes = 100 * 1024 * 1024 // 100 MB
+
+        // 1. Validate extension
+        if (extension != "csv" && extension != "xlsx") {
+            return Result.failure(IllegalArgumentException("Please upload a .xlsx or .csv file to continue."))
         }
+
+        // 2. Validate size
+        if (fileSizeBytes > maxSizeBytes) {
+            return Result.failure(IllegalArgumentException("Please upload a smaller dataset (Max 100 MB)."))
+        }
+
+        return Result.success(Unit)
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/CreateScreen/CreateView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/CreateScreen/CreateView.kt
@@ -175,7 +175,7 @@ fun DashedSelector(onClick: () -> Unit) {
                 fontWeight = FontWeight.Medium,
                 color = TealPrimary
             )
-            Text("Minimum file size: 100 MB", fontSize = 12.sp, color = TextGray)
+            Text("Maximum file size: 100 MB", fontSize = 12.sp, color = TextGray)
             Text("Only one dataset can be uploaded.", fontSize = 12.sp, color = TextGray)
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/CreateScreen/CreateViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/CreateScreen/CreateViewModel.kt
@@ -25,15 +25,16 @@ class CreateViewModel(
         if (uri == null) return
 
         val fileName = getFileName(context, uri) ?: "unknown_file"
-        val fileSize = getFileSize(context, uri) ?: "0 MB"
+        val sizeInBytes = getFileSizeBytes(context, uri)
+        val fileSizeFormatted = formatFileSize(sizeInBytes)
 
-        validateDatasetUseCase(fileName).onSuccess {
-            startUpload(fileName, fileSize)
+        validateDatasetUseCase(fileName, sizeInBytes).onSuccess {
+            startUpload(fileName, fileSizeFormatted)
         }.onFailure { exception ->
             _uiState.value = CreateUiState.Error(
                 message = exception.message ?: "Unsupported format",
                 fileName = fileName,
-                fileSize = fileSize
+                fileSize = fileSizeFormatted
             )
         }
     }
@@ -66,7 +67,7 @@ class CreateViewModel(
         return name
     }
 
-    private fun getFileSize(context: Context, uri: Uri): String? {
+    private fun getFileSizeBytes(context: Context, uri: Uri): Long {
         var size: Long = 0
         context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
             if (cursor.moveToFirst()) {
@@ -74,7 +75,11 @@ class CreateViewModel(
                 if (index != -1) size = cursor.getLong(index)
             }
         }
-        val mbSize = size / (1024f * 1024f)
+        return size
+    }
+
+    private fun formatFileSize(sizeInBytes: Long): String {
+        val mbSize = sizeInBytes / (1024f * 1024f)
         return String.format(Locale.ROOT, "%.1f MB", mbSize)
     }
 }


### PR DESCRIPTION
The previous merged version lacked strict 100MB file size validation and contained a typo in the UI ("Minimum" instead of "Maximum").

- Updated ValidateDatasetUseCase to enforce a 100MB limit.
- Corrected the label in CreateView to show "Maximum file size".
- Refactored CreateViewModel to handle size verification in bytes.

- Domain: Added byte-size check in ValidateDatasetUseCase.
- Presentation: Updated CreateView text and CreateViewModel logic.