### PR TITLE
Added charts selection screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.material.icons.extended)
     implementation(libs.firebase.firestore.ktx)
     implementation(libs.androidx.navigation.runtime.ktx)
+    implementation(libs.androidx.navigation.compose) // Added this for NavHost and composable
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/oracle/visualize/domain/models/ChartSelectionUiState.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ChartSelectionUiState.kt
@@ -12,12 +12,12 @@ sealed interface ChartSelectionUiState {
     ) : ChartSelectionUiState
 
     data class Error(val message: String) : ChartSelectionUiState
-}
 
-/**
- * Wrapper for Visualization with selection state.
- */
-data class VisualizationSelection(
-    val visualization: Visualization,
-    val isSelected: Boolean = false
-)
+    /**
+     * Wrapper for Visualization with selection state.
+     */
+    data class VisualizationSelection(
+        val visualization: Visualization,
+        val isSelected: Boolean = false
+    )
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/createChartScreen/CreateChartView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/createChartScreen/CreateChartView.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.oracle.visualize.R
-import com.oracle.visualize.presentation.screens.createChartScreen.CreateChartViewModel
 import com.oracle.visualize.presentation.screens.createChartScreen.components.FileStatusItem
 
 /**
@@ -36,11 +35,11 @@ import com.oracle.visualize.presentation.screens.createChartScreen.components.Fi
 fun CreatePage(
     modifier: Modifier = Modifier,
     viewModel: CreateChartViewModel = viewModel(),
+    onNavigateToSelection: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
 
-    // Using GetContent for broader support of cloud providers like Google Drive
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent(),
         onResult = { uri ->
@@ -109,7 +108,7 @@ fun CreatePage(
 
             if (uiState is CreateChartUiState.Success) {
                 Button(
-                    onClick = { /**/ },
+                    onClick = onNavigateToSelection,
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(56.dp),
@@ -127,6 +126,7 @@ fun CreatePage(
     }
 }
 
+// Additional components (DashedSelector, FileStatusSection, etc. remain unchanged)
 @Composable
 fun DashedSelector(onClick: () -> Unit) {
     Box(

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
@@ -17,7 +17,8 @@ import com.oracle.visualize.presentation.components.BottomNavBar
 import com.oracle.visualize.presentation.screens.createChartScreen.CreatePage
 import com.oracle.visualize.presentation.screens.feedScreen.FeedPage
 import com.oracle.visualize.presentation.screens.notificationScreen.NotificationPage
-
+import com.oracle.visualize.presentation.screens.selectchartscreen.SelectChartView
+import com.oracle.visualize.presentation.screens.shareScreen.ShareAndPostScreen
 
 // Bottom nav destinations — screens outside this list hide the nav bar
 private val bottomNavRoutes = setOf(
@@ -28,6 +29,9 @@ private val bottomNavRoutes = setOf(
     NavRoutes.Profile.route
 )
 
+/**
+ * The main container screen that manages the bottom navigation and the NavHost.
+ */
 @Composable
 fun MainScreen(
     viewModel: MainViewModel = viewModel(),
@@ -61,6 +65,9 @@ fun MainScreen(
 
 // ─── NavHost ──────────────────────────────────────────────────────────────────
 
+/**
+ * Manages the navigation between different screens of the application.
+ */
 @Composable
 fun AppNavHost(
     navController: NavHostController,
@@ -68,6 +75,7 @@ fun AppNavHost(
 ) {
     NavHost(
         navController = navController,
+        // Set the start destination. Change this to other routes (e.g., NavRoutes.ChartSelection.route) for testing purposes.
         startDestination = NavRoutes.Feed.route,
         modifier = modifier
     ) {
@@ -76,17 +84,30 @@ fun AppNavHost(
         }
 
         composable(NavRoutes.Create.route) {
-            CreatePage(modifier = Modifier.fillMaxSize())
+            CreatePage(
+                onNavigateToSelection = {
+                    navController.navigate(NavRoutes.ChartSelection.route)
+                },
+                modifier = Modifier.fillMaxSize()
+            )
         }
 
         composable(NavRoutes.Notifications.route) {
             NotificationPage(modifier = Modifier.fillMaxSize())
         }
 
-        /* Share screen — no bottom bar, navigates back to Feed
+        composable(NavRoutes.ChartSelection.route) {
+            SelectChartView(
+                onBack = { navController.popBackStack() },
+                onNavigateToShare = { navController.navigate(NavRoutes.Share.route) }
+            )
+        }
+
         composable(NavRoutes.Share.route) {
-                // TODO: Add TeamsPage when implemented
-        }*/
+            ShareAndPostScreen(
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
 
         // Teams and Profile — placeholders until screens are implemented
         composable(NavRoutes.Teams.route) {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/components/ChartCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/components/ChartCard.kt
@@ -1,11 +1,10 @@
-package com.oracle.visualize.presentation.screens.selectChartScreen.components
+package com.oracle.visualize.presentation.screens.selectchartscreen.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
@@ -13,121 +12,106 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.oracle.visualize.R
 import com.oracle.visualize.domain.models.Visualization
-import com.oracle.visualize.ui.theme.*
 
+/**
+ * A card component that displays a chart preview with interactive selection and title editing.
+ */
 @Composable
 fun ChartCard(
     visualization: Visualization,
     isSelected: Boolean,
     onSelect: () -> Unit,
-    onEditTitle: () -> Unit
+    onEditTitle: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    val topBottomBackground = if (isSelected) MaterialTheme.colorScheme.primary else Color.White
-    val contentColor = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onPrimaryContainer
-    val iconColor = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onPrimaryContainer
+    val headerBg = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val onHeaderColor = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    val borderColor = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
 
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)
             .border(
                 width = 2.dp,
-                color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                color = borderColor,
                 shape = RoundedCornerShape(12.dp)
             )
             .clickable { onSelect() },
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-
+            // Header Section: Supports multi-line titles with character limit
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(topBottomBackground)
-                    .padding(16.dp),
+                    .background(headerBg)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.Top
             ) {
                 Text(
                     text = visualization.title,
                     modifier = Modifier.weight(1f),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    color = contentColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    color = onHeaderColor,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = 20.sp
                 )
-                IconButton(
-                    onClick = onEditTitle,
-                    modifier = Modifier.size(24.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Edit,
-                        contentDescription = "Edit Title",
-                        modifier = Modifier.size(20.dp),
-                        tint = iconColor
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(R.string.dialog_edit_title),
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .size(20.dp)
+                        .clickable { onEditTitle() },
+                    tint = onHeaderColor
+                )
             }
 
+            // Middle Section: Chart fills the center (Legend removed as per requirements)
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(180.dp)
-                    .background(Color(0xFFF9F9F9))
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .height(240.dp)
+                    .background(MaterialTheme.colorScheme.surface)
+                    .padding(16.dp)
             ) {
                 MockChartContent()
-            }
-
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(topBottomBackground)
-                    .padding(12.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                LegendItem(color = Color.Blue, text = "Units Sold", textColor = contentColor)
-                Spacer(modifier = Modifier.width(16.dp))
-                LegendItem(color = Color.Yellow, text = "Total Transactions", textColor = contentColor)
             }
         }
     }
 }
 
 @Composable
-fun MockChartContent() {
+private fun MockChartContent() {
+    val barColor = MaterialTheme.colorScheme.primary
+    val lineColor = MaterialTheme.colorScheme.secondary
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f)) {
-            Column(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .padding(bottom = 20.dp),
-                verticalArrangement = Arrangement.SpaceBetween
-            ) {
-                listOf("20,000", "15,000", "10,000", "5,000", "0").forEach { label ->
-                    Text(text = label, fontSize = 8.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                }
-            }
-
+            // Grid and Data
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(start = 35.dp, bottom = 20.dp, end = 8.dp)
+                    .padding(start = 24.dp, bottom = 16.dp)
             ) {
+                // Background Grid
                 Column(
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.SpaceBetween
@@ -136,32 +120,32 @@ fun MockChartContent() {
                         HorizontalDivider(
                             modifier = Modifier.fillMaxWidth(),
                             thickness = 0.5.dp,
-                            color = Color.LightGray.copy(alpha = 0.4f)
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f)
                         )
                     }
                 }
 
+                // Bar Chart
                 Row(
                     modifier = Modifier.fillMaxSize(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.Bottom
                 ) {
-                    val barHeights = listOf(0.4f, 0.7f, 0.5f, 0.9f, 0.6f, 0.8f, 0.4f, 0.5f)
+                    val barHeights = listOf(0.4f, 0.7f, 0.5f, 0.9f, 0.6f, 0.8f)
                     barHeights.forEach { h ->
                         Box(
                             modifier = Modifier
                                 .fillMaxHeight(h)
-                                .width(10.dp)
-                                .background(Color.Blue)
+                                .width(16.dp)
+                                .background(barColor, RoundedCornerShape(topStart = 2.dp, topEnd = 2.dp))
                         )
                     }
                 }
 
+                // Line Chart
                 Canvas(modifier = Modifier.fillMaxSize()) {
-                    val orangeLine = Color.Yellow
-                    val points = listOf(0.7f, 0.5f, 0.8f, 0.4f, 0.7f, 0.3f, 0.6f, 0.4f)
+                    val points = listOf(0.7f, 0.5f, 0.8f, 0.4f, 0.7f, 0.6f)
                     val path = Path()
-                    
                     val stepX = size.width / (points.size - 1)
                     
                     points.forEachIndexed { index, h ->
@@ -172,37 +156,11 @@ fun MockChartContent() {
                     
                     drawPath(
                         path = path,
-                        color = orangeLine,
+                        color = lineColor,
                         style = Stroke(width = 2.dp.toPx())
                     )
                 }
             }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.BottomStart)
-                    .padding(start = 35.dp, end = 8.dp),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                listOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug").forEach { month ->
-                    Text(text = month, fontSize = 8.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                }
-            }
         }
-    }
-}
-
-@Composable
-fun LegendItem(color: Color, text: String, textColor: Color) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(
-            modifier = Modifier
-                .size(8.dp)
-                .clip(CircleShape)
-                .background(color)
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        Text(text = text, fontSize = 9.sp, color = textColor)
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/selectChartMockData.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/selectChartMockData.kt
@@ -1,4 +1,4 @@
-package com.oracle.visualize.presentation.screens.selectChartScreen
+package com.oracle.visualize.presentation.screens.selectchartscreen
 
 import com.oracle.visualize.domain.models.Visualization
 import com.google.firebase.Timestamp
@@ -7,7 +7,7 @@ import java.util.UUID
 /**
  * Mock data for development and testing purposes.
  */
-object selectChartMockData {
+object SelectChartMockData {
     val visualizations = listOf(
         Visualization(
             id = UUID.randomUUID().toString(),

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/selectChartView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/selectChartView.kt
@@ -1,4 +1,4 @@
-package com.oracle.visualize.presentation.screens.selectChartScreen
+package com.oracle.visualize.presentation.screens.selectchartscreen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -17,22 +17,25 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.oracle.visualize.domain.models.ChartSelectionUiState
-import com.oracle.visualize.presentation.screens.selectChartScreen.components.ChartCard
-import com.oracle.visualize.ui.theme.*
 import com.oracle.visualize.R
+import com.oracle.visualize.domain.models.ChartSelectionUiState
+import com.oracle.visualize.presentation.screens.selectchartscreen.components.ChartCard
 
-
+/**
+ * Screen that displays suggested charts as interactive cards.
+ * Users can select one or more charts and edit their titles before publishing.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChartSelectionPage(
+fun SelectChartView(
     onBack: () -> Unit,
     onNavigateToShare: () -> Unit,
-    viewModel: selectChartViewModel = viewModel()
+    viewModel: SelectChartViewModel = viewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    var showEditDialog by remember { mutableStateOf<String?>(null) }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var chartIdToEdit by remember { mutableStateOf<String?>(null) }
     var tempTitle by remember { mutableStateOf("") }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
@@ -44,18 +47,28 @@ fun ChartSelectionPage(
                 title = {
                     Text(
                         text = stringResource(R.string.chart_selection_title),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 20.sp
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.icon_back))
+                    IconButton(onClick = {
+                        if (viewModel.hasSelections()) {
+                            viewModel.showUnsavedChangesDialog(true)
+                        } else {
+                            onBack()
+                        }
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.icon_back)
+                        )
                     }
                 },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             )
         },
@@ -63,20 +76,22 @@ fun ChartSelectionPage(
         when (val state = uiState) {
             is ChartSelectionUiState.Loading -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                    CircularProgressIndicator()
                 }
             }
             is ChartSelectionUiState.Error -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(text = state.message, color = ErrorRed)
+                    Text(text = state.message, color = MaterialTheme.colorScheme.error)
                 }
             }
             is ChartSelectionUiState.Success -> {
                 LazyColumn(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(paddingValues)
+                        .padding(paddingValues),
+                    contentPadding = PaddingValues(bottom = 16.dp)
                 ) {
+                    // Header Section
                     item {
                         Column(
                             modifier = Modifier
@@ -86,27 +101,29 @@ fun ChartSelectionPage(
                         ) {
                             Text(
                                 text = stringResource(R.string.chart_selection_ready_title),
-                                color = Color.White,
-                                fontWeight = FontWeight.Bold,
-                                fontSize = 14.sp
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold
                             )
                             Text(
                                 text = stringResource(R.string.chart_selection_ready_subtitle),
-                                color = Color.White.copy(alpha = 0.9f),
-                                fontSize = 12.sp
+                                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
+                                style = MaterialTheme.typography.bodySmall
                             )
                         }
                     }
 
+                    // Prompt Section
                     item {
                         Text(
                             text = stringResource(R.string.chart_selection_prompt),
                             modifier = Modifier.padding(16.dp),
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            fontSize = 14.sp
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground
                         )
                     }
 
+                    // Interactive Chart Cards
                     items(state.charts) { selection ->
                         Box(modifier = Modifier.padding(horizontal = 16.dp)) {
                             ChartCard(
@@ -115,12 +132,13 @@ fun ChartSelectionPage(
                                 onSelect = { viewModel.toggleSelection(selection.visualization.id) },
                                 onEditTitle = {
                                     tempTitle = selection.visualization.title
-                                    showEditDialog = selection.visualization.id
+                                    chartIdToEdit = selection.visualization.id
                                 }
                             )
                         }
                     }
 
+                    // Action Buttons
                     item {
                         Row(
                             modifier = Modifier
@@ -129,13 +147,16 @@ fun ChartSelectionPage(
                             horizontalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             Button(
-                                onClick = {},
+                                onClick = { /* Logic for personal feed */ },
                                 modifier = Modifier.weight(1f).height(48.dp),
                                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary),
                                 shape = RoundedCornerShape(8.dp),
                                 enabled = viewModel.hasSelections()
                             ) {
-                                Text(stringResource(R.string.chart_selection_post_personal), color = Color.White, fontSize = 12.sp)
+                                Text(
+                                    text = stringResource(R.string.chart_selection_post_personal),
+                                    style = MaterialTheme.typography.labelLarge
+                                )
                             }
 
                             Button(
@@ -145,16 +166,20 @@ fun ChartSelectionPage(
                                 shape = RoundedCornerShape(8.dp),
                                 enabled = viewModel.hasSelections()
                             ) {
-                                Text(stringResource(R.string.chart_selection_share_and_post), color = Color.White, fontSize = 12.sp)
+                                Text(
+                                    text = stringResource(R.string.chart_selection_share_and_post),
+                                    style = MaterialTheme.typography.labelLarge
+                                )
                             }
                         }
                     }
                 }
 
-                if (showEditDialog != null) {
+                // Edit Title Dialog
+                if (chartIdToEdit != null) {
                     AlertDialog(
-                        onDismissRequest = { showEditDialog = null },
-                        title = { Text(stringResource(R.string.dialog_edit_title), fontWeight = FontWeight.Bold) },
+                        onDismissRequest = { chartIdToEdit = null },
+                        title = { Text(stringResource(R.string.dialog_edit_title)) },
                         text = {
                             OutlinedTextField(
                                 value = tempTitle,
@@ -165,36 +190,37 @@ fun ChartSelectionPage(
                         },
                         confirmButton = {
                             TextButton(onClick = {
-                                showEditDialog?.let { viewModel.updateChartTitle(it, tempTitle) }
-                                showEditDialog = null
+                                chartIdToEdit?.let { viewModel.updateChartTitle(it, tempTitle) }
+                                chartIdToEdit = null
                             }) {
-                                Text(stringResource(R.string.confirm), color = MaterialTheme.colorScheme.primary)
+                                Text(stringResource(R.string.confirm))
                             }
                         },
                         dismissButton = {
-                            TextButton(onClick = { showEditDialog = null }) {
-                                Text(stringResource(R.string.cancel), color = MaterialTheme.colorScheme.onPrimaryContainer)
+                            TextButton(onClick = { chartIdToEdit = null }) {
+                                Text(stringResource(R.string.cancel))
                             }
                         }
                     )
                 }
 
+                // Unsaved Changes Dialog
                 if (state.isUnsavedChangesDialogVisible) {
                     AlertDialog(
                         onDismissRequest = { viewModel.showUnsavedChangesDialog(false) },
-                        title = { Text(stringResource(R.string.dialog_unsaved_title), fontWeight = FontWeight.Bold) },
+                        title = { Text(stringResource(R.string.dialog_unsaved_title)) },
                         text = { Text(stringResource(R.string.dialog_unsaved_message)) },
                         confirmButton = {
                             TextButton(onClick = {
                                 viewModel.showUnsavedChangesDialog(false)
                                 onBack()
                             }) {
-                                Text(stringResource(R.string.dialog_leave), color = ErrorRed)
+                                Text(stringResource(R.string.dialog_leave), color = MaterialTheme.colorScheme.error)
                             }
                         },
                         dismissButton = {
                             TextButton(onClick = { viewModel.showUnsavedChangesDialog(false) }) {
-                                Text(stringResource(R.string.cancel), color = MaterialTheme.colorScheme.onPrimaryContainer)
+                                Text(stringResource(R.string.cancel))
                             }
                         }
                     )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/selectChartViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/selectChartViewModel.kt
@@ -1,27 +1,36 @@
-package com.oracle.visualize.presentation.screens.selectChartScreen
+package com.oracle.visualize.presentation.screens.selectchartscreen
 
 import androidx.lifecycle.ViewModel
 import com.oracle.visualize.domain.models.ChartSelectionUiState
-import com.oracle.visualize.domain.models.VisualizationSelection
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-class selectChartViewModel : ViewModel() {
+/**
+ * ViewModel for the Chart Selection screen.
+ * Manages the state of suggested charts and user selections.
+ */
+class SelectChartViewModel : ViewModel() {
 
     private val _uiState = MutableStateFlow<ChartSelectionUiState>(ChartSelectionUiState.Loading)
     val uiState: StateFlow<ChartSelectionUiState> = _uiState.asStateFlow()
 
     init {
-        loadMockCharts()
+        loadSuggestedCharts()
     }
 
-    private fun loadMockCharts() {
-        val mockCharts = selectChartMockData.visualizations.map { VisualizationSelection(it) }
+    private fun loadSuggestedCharts() {
+        // Load data from mock source for now
+        val mockCharts = SelectChartMockData.visualizations.map { 
+            ChartSelectionUiState.VisualizationSelection(it) 
+        }
         _uiState.value = ChartSelectionUiState.Success(charts = mockCharts)
     }
 
+    /**
+     * Toggles the selection status of a chart.
+     */
     fun toggleSelection(chartId: String) {
         val currentState = _uiState.value
         if (currentState is ChartSelectionUiState.Success) {
@@ -36,6 +45,9 @@ class selectChartViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Updates the title of a specific chart.
+     */
     fun updateChartTitle(chartId: String, newTitle: String) {
         val currentState = _uiState.value
         if (currentState is ChartSelectionUiState.Success) {
@@ -51,6 +63,9 @@ class selectChartViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Controls the visibility of the unsaved changes warning.
+     */
     fun showUnsavedChangesDialog(show: Boolean) {
         val currentState = _uiState.value
         if (currentState is ChartSelectionUiState.Success) {
@@ -58,6 +73,9 @@ class selectChartViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Checks if at least one chart is selected for publishing.
+     */
     fun hasSelections(): Boolean {
         val currentState = _uiState.value
         return if (currentState is ChartSelectionUiState.Success) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "l
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore"}
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationRuntimeKtx" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }


### PR DESCRIPTION
This PR introduces the suggested charts selection screen, allowing users to interactively preview and choose visualizations generated from their datasets before publishing.
•Feature: Implemented SelectChartView and SelectChartViewModel for multi-chart selection.
•UI/UX: Created ChartCard component with a 3-section layout, clean edit icons, and dynamic selection effects (header/footer background and text color changes) following Figma specs.
•Navigation: Integrated Jetpack Compose Navigation via AppNavHost and updated libs.versions.toml.
•Logic: Connected the "Generate Visualizations" button in CreatePage to the new selection flow.
•Standards: All UI strings are moved to strings.xml, used the standardized color palette for Dark Mode support, and ensured all code comments are in English.