### PR TITLE
Use Case Unit Tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation.layout)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/test/java/com/oracle/visualize/fixtures/DatasetFixtures.kt
+++ b/app/src/test/java/com/oracle/visualize/fixtures/DatasetFixtures.kt
@@ -1,0 +1,9 @@
+package com.oracle.visualize.fixtures
+
+object DatasetFixtures {
+    const val VALID_CSV_NAME  = "data.csv"
+    const val VALID_XLSX_NAME = "data.xlsx"
+
+    const val VALID_SIZE = 1 * 1024 * 1024L         // 1 MB
+    const val MAX_SIZE   = 100 * 1024 * 1024L        // 100 MB
+}

--- a/app/src/test/java/com/oracle/visualize/fixtures/UserFixtures.kt
+++ b/app/src/test/java/com/oracle/visualize/fixtures/UserFixtures.kt
@@ -1,0 +1,23 @@
+package com.oracle.visualize.fixtures
+
+import com.oracle.visualize.domain.models.AuthUser
+import com.oracle.visualize.domain.models.ShareUser
+
+object UserFixtures {
+
+    const val VALID_EMAIL = "test@test.com"
+    const val VALID_PASSWORD = "123456"
+    const val VALID_UID = "user123"
+
+    val fakeAuthUser = AuthUser(
+        uid = VALID_UID,
+        email = VALID_EMAIL
+    )
+
+    const val VALID_QUERY = "john"
+
+    val fakeShareUsers = listOf(
+        ShareUser(id = "1", username = "Claudia", email = "test@test.com", profilePictureURL = null),
+        ShareUser(id = "2",username = "Joshua", email = "test2@test.com", profilePictureURL = "url"),
+    )
+}

--- a/app/src/test/java/com/oracle/visualize/fixtures/VisualizationFixtures.kt
+++ b/app/src/test/java/com/oracle/visualize/fixtures/VisualizationFixtures.kt
@@ -1,0 +1,24 @@
+package com.oracle.visualize.fixtures
+
+import com.oracle.visualize.domain.models.VisualizationCard
+import java.util.Date
+
+object VisualizationFixtures {
+
+    const val VALID_USER_ID = "user123"
+
+    val fakeVisualizationCard = VisualizationCard(
+        id = "1",
+        title = "Chart A",
+        author = "John",
+        createdAt = Date(),
+        sharedWith = emptyList(),
+        configJSON = "{}"
+    )
+
+    val fakeVisualizations = listOf(
+        fakeVisualizationCard,
+        fakeVisualizationCard.copy(id = "2", title = "Chart B")
+    )
+
+}

--- a/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
@@ -1,0 +1,154 @@
+package com.oracle.visualize.usecases
+
+import com.oracle.visualize.domain.exceptions.AppError
+import com.oracle.visualize.domain.models.VisualizationCard
+import com.oracle.visualize.domain.models.enums.VisualizationFilter
+import com.oracle.visualize.domain.repositories.VisualizationRepository
+import com.oracle.visualize.domain.usecases.GetAllUserVisualizationsUseCase
+import com.oracle.visualize.fixtures.VisualizationFixtures
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [GetAllUserVisualizationsUseCase].
+ *
+ *   GetAllUserVisualizationsUseCase validates the userID before delegating
+ *   to [VisualizationRepository]. The UseCase has no filter logic,
+ *   it ensures the filter is forwarded
+ *   correctly and that repository exceptions are caught and wrapped in
+ *   Result.isFailure instead of crashing the caller.
+ */
+
+class GetAllUserVisualizationsUCTest {
+
+    @MockK
+    private lateinit var visualizationRepository: VisualizationRepository
+    private lateinit var getAllUserVisualizations: GetAllUserVisualizationsUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        getAllUserVisualizations = GetAllUserVisualizationsUseCase(visualizationRepository)
+    }
+
+    // No user ID
+
+    @Test
+    fun blankUserID_returnsValidationError_doesNotCallRepository() = runTest {
+        // given
+        val blankUserID = ""
+
+        // when
+        val result = getAllUserVisualizations(blankUserID, VisualizationFilter.ALL)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) {
+            visualizationRepository.getAllVisualizationsByUserID(any(), any())
+        }
+    }
+
+    //Calls to the Repository
+
+    @Test
+    fun validUserID_returnsResultSuccess_withVisualizationList() = runTest {
+        // given
+        coEvery {
+            visualizationRepository.getAllVisualizationsByUserID(
+                VisualizationFixtures.VALID_USER_ID,
+                VisualizationFilter.ALL
+            )
+        } returns VisualizationFixtures.fakeVisualizations
+
+        // when
+        val result = getAllUserVisualizations(
+            VisualizationFixtures.VALID_USER_ID,
+            VisualizationFilter.ALL
+        )
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(VisualizationFixtures.fakeVisualizations, result.getOrNull())
+        coVerify(exactly = 1) {
+            visualizationRepository.getAllVisualizationsByUserID(
+                VisualizationFixtures.VALID_USER_ID,
+                VisualizationFilter.ALL
+            )
+        }
+    }
+
+    @Test
+    fun validUserID_withNoVisualizations_returnsEmptyList() = runTest {
+        // given
+        coEvery {
+            visualizationRepository.getAllVisualizationsByUserID(
+                VisualizationFixtures.VALID_USER_ID,
+                VisualizationFilter.ALL
+            )
+        } returns emptyList()
+
+        // when
+        val result = getAllUserVisualizations(
+            VisualizationFixtures.VALID_USER_ID,
+            VisualizationFilter.ALL
+        )
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<VisualizationCard>(), result.getOrNull())
+    }
+
+    @Test
+    fun filterIsForwardedToRepository() = runTest {
+        // given - verify the filter enum is forwarded, not hardcoded
+        coEvery {
+            visualizationRepository.getAllVisualizationsByUserID(
+                VisualizationFixtures.VALID_USER_ID,
+                VisualizationFilter.PERSONAL
+            )
+        } returns VisualizationFixtures.fakeVisualizations
+
+        // when
+        getAllUserVisualizations(
+            VisualizationFixtures.VALID_USER_ID,
+            VisualizationFilter.PERSONAL
+        )
+
+        // then
+        coVerify(exactly = 1) {
+            visualizationRepository.getAllVisualizationsByUserID(
+                VisualizationFixtures.VALID_USER_ID,
+                VisualizationFilter.PERSONAL
+            )
+        }
+    }
+
+    @Test
+    fun repositoryThrows_returnsResultFailure() = runTest {
+        // given
+        val exception = Exception("Firestore unavailable")
+        coEvery {
+            visualizationRepository.getAllVisualizationsByUserID(any(), any())
+        } throws exception
+
+        // when
+        val result = getAllUserVisualizations(
+            VisualizationFixtures.VALID_USER_ID,
+            VisualizationFilter.ALL
+        )
+
+        // then
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+
+}

--- a/app/src/test/java/com/oracle/visualize/usecases/GetUserSuggestionsUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/GetUserSuggestionsUCTest.kt
@@ -1,0 +1,107 @@
+package com.oracle.visualize.usecases
+
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.domain.repositories.UserRepository
+import com.oracle.visualize.domain.usecases.GetUserSuggestionsUseCase
+import com.oracle.visualize.fixtures.UserFixtures
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class GetUserSuggestionsUCTest {
+    @MockK
+    private lateinit var userRepository: UserRepository
+    private lateinit var getUserSuggestionsUseCase: GetUserSuggestionsUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        getUserSuggestionsUseCase = GetUserSuggestionsUseCase(userRepository)
+    }
+
+    //Query Validation
+
+    @Test
+    fun blankQuery_returnsSuccessEmptyList_doesNotCallRepository() = runTest {
+        // given
+        val blankQuery = ""
+
+        // when
+        val result = getUserSuggestionsUseCase(blankQuery)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<ShareUser>(), result.getOrNull())
+        coVerify(exactly = 0) { userRepository.getUserSuggestionsByEmail(any()) }
+    }
+
+    @Test
+    fun whitespaceQuery_returnsSuccessEmptyList_doesNotCallRepository() = runTest {
+        // given
+        val whitespaceQuery = "   "
+
+        // when
+        val result = getUserSuggestionsUseCase(whitespaceQuery)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<ShareUser>(), result.getOrNull())
+        coVerify(exactly = 0) { userRepository.getUserSuggestionsByEmail(any()) }
+    }
+
+    //Call Repository
+
+    @Test
+    fun validQuery_returnsResultSuccess_withUserList() = runTest {
+        // given
+        coEvery {
+            userRepository.getUserSuggestionsByEmail(UserFixtures.VALID_QUERY)
+        } returns UserFixtures.fakeShareUsers
+
+        // when
+        val result = getUserSuggestionsUseCase(UserFixtures.VALID_QUERY)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(UserFixtures.fakeShareUsers, result.getOrNull())
+        coVerify(exactly = 1) { userRepository.getUserSuggestionsByEmail(UserFixtures.VALID_QUERY) }
+    }
+
+    @Test
+    fun validQuery_withNoMatches_returnsSuccessEmptyList() = runTest {
+        // given
+        coEvery {
+            userRepository.getUserSuggestionsByEmail(UserFixtures.VALID_QUERY)
+        } returns emptyList()
+
+        // when
+        val result = getUserSuggestionsUseCase(UserFixtures.VALID_QUERY)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<ShareUser>(), result.getOrNull())
+    }
+
+    @Test
+    fun repositoryThrows_returnsResultFailure() = runTest {
+        // given
+        val exception = Exception("Network error")
+        coEvery {
+            userRepository.getUserSuggestionsByEmail(any())
+        } throws exception
+
+        // when
+        val result = getUserSuggestionsUseCase(UserFixtures.VALID_QUERY)
+
+        // then
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+}

--- a/app/src/test/java/com/oracle/visualize/usecases/LogOutUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/LogOutUCTest.kt
@@ -34,7 +34,7 @@ class LogOutUCTest {
     }
 
     @Test
-    fun `calls repository once`() {
+    fun callRepository() {
         // No values given
         every { authRepository.logout() } just Runs
 

--- a/app/src/test/java/com/oracle/visualize/usecases/LogOutUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/LogOutUCTest.kt
@@ -1,0 +1,47 @@
+package com.oracle.visualize.usecases
+
+import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.usecases.LogoutUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+
+/**
+ * Unit tests for [LogoutUseCase].
+ *
+ *   LogoutUseCase just clears the cache of the token, without a network call.
+ *   Does not need a coroutine.
+
+ */
+
+class LogOutUCTest {
+
+    @MockK
+    private lateinit var authRepository: AuthRepository
+    private lateinit var logoutUseCase: LogoutUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        logoutUseCase = LogoutUseCase(authRepository)
+    }
+
+    @Test
+    fun `calls repository once`() {
+        // No values given
+        every { authRepository.logout() } just Runs
+
+        // when
+        logoutUseCase()
+
+        // then
+        verify(exactly = 1) { authRepository.logout() }
+    }
+}

--- a/app/src/test/java/com/oracle/visualize/usecases/LoginUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/LoginUCTest.kt
@@ -1,0 +1,143 @@
+package com.oracle.visualize.usecases
+
+import com.oracle.visualize.domain.exceptions.AppError
+import com.oracle.visualize.domain.models.AuthUser
+import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.usecases.LoginUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [LoginUseCase].
+ *
+ *   LoginUseCase validates email and password before delegating to
+ *   [AuthRepository]. It wraps results in [Result] instead of throwing,
+ *   so we assert on Result.isSuccess / Result.isFailure and the specific
+ *   error type rather than catching exceptions.
+
+ */
+
+class LoginUCTest {
+
+    @MockK
+    private lateinit var authRepository: AuthRepository
+    private lateinit var loginUseCase: LoginUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        loginUseCase = LoginUseCase(authRepository)
+    }
+
+    //Email Validation
+
+    @Test
+    fun `blank email returns ValidationError and does not call repository`() = runTest {
+        // given
+        val blankEmail = ""
+        val anyPassword = "123456"
+
+        // when
+        val result = loginUseCase(blankEmail, anyPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.login(any(), any()) }
+    }
+
+    @Test
+    fun `invalid email format returns ValidationError and does not call repository`() = runTest {
+        // given
+        val invalidEmail = "notanemail"
+        val anyPassword = "123456"
+
+        // when
+        val result = loginUseCase(invalidEmail, anyPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.login(any(), any()) }
+    }
+
+    @Test
+    fun `email without TLD returns ValidationError and does not call repository`() = runTest {
+        // given
+        val emailWithoutTLD = "test@test"
+        val anyPassword = "123456"
+
+        // when
+        val result = loginUseCase(emailWithoutTLD, anyPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.login(any(), any()) }
+    }
+
+
+    //Password Validation
+
+    @Test
+    fun `blank password returns ValidationError and does not call repository`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val blankPassword = ""
+
+        // when
+        val result = loginUseCase(validEmail, blankPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.login(any(), any()) }
+    }
+
+    //Repository
+
+    @Test
+    fun `valid credentials return Result success with AuthUser`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val validPassword = "123456"
+        val fakeUser = AuthUser(uid = "123", email = validEmail)
+        coEvery { authRepository.login(validEmail, validPassword) } returns fakeUser
+
+        // when
+        val result = loginUseCase(validEmail, validPassword)
+
+        // then
+        assertTrue(
+            "Expected success but got: ${result.exceptionOrNull()?.message}",
+            result.isSuccess
+        )
+        assertEquals(fakeUser, result.getOrNull())
+        coVerify(exactly = 1) { authRepository.login(validEmail, validPassword) }
+    }
+
+    @Test
+    fun `repository exception is caught and returned as Result failure`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val validPassword = "123456"
+        val exception = Exception("Invalid credentials")
+        coEvery { authRepository.login(any(), any()) } throws exception
+
+        // when
+        val result = loginUseCase(validEmail, validPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+
+}

--- a/app/src/test/java/com/oracle/visualize/usecases/LoginUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/LoginUCTest.kt
@@ -1,7 +1,6 @@
 package com.oracle.visualize.usecases
 
 import com.oracle.visualize.domain.exceptions.AppError
-import com.oracle.visualize.domain.models.AuthUser
 import com.oracle.visualize.domain.repositories.AuthRepository
 import com.oracle.visualize.domain.usecases.LoginUseCase
 import io.mockk.MockKAnnotations
@@ -13,6 +12,7 @@ import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import com.oracle.visualize.fixtures.UserFixtures
 
 /**
  * Unit tests for [LoginUseCase].
@@ -39,13 +39,12 @@ class LoginUCTest {
     //Email Validation
 
     @Test
-    fun `blank email returns ValidationError and does not call repository`() = runTest {
+    fun blankEmail_returnsValidationError_doesNotCallRepository() = runTest {
         // given
         val blankEmail = ""
-        val anyPassword = "123456"
 
         // when
-        val result = loginUseCase(blankEmail, anyPassword)
+        val result = loginUseCase(blankEmail, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)
@@ -54,13 +53,12 @@ class LoginUCTest {
     }
 
     @Test
-    fun `invalid email format returns ValidationError and does not call repository`() = runTest {
+    fun invalidEmailFormat_returnsValidationError_doesNotCallRepository() = runTest {
         // given
         val invalidEmail = "notanemail"
-        val anyPassword = "123456"
 
         // when
-        val result = loginUseCase(invalidEmail, anyPassword)
+        val result = loginUseCase(invalidEmail, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)
@@ -69,13 +67,12 @@ class LoginUCTest {
     }
 
     @Test
-    fun `email without TLD returns ValidationError and does not call repository`() = runTest {
+    fun emailWithoutTLD_returnsValidationError_doesNotCallRepository() = runTest {
         // given
         val emailWithoutTLD = "test@test"
-        val anyPassword = "123456"
 
         // when
-        val result = loginUseCase(emailWithoutTLD, anyPassword)
+        val result = loginUseCase(emailWithoutTLD, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)
@@ -87,13 +84,12 @@ class LoginUCTest {
     //Password Validation
 
     @Test
-    fun `blank password returns ValidationError and does not call repository`() = runTest {
+    fun blankPassword_returnsValidationError_doesNotCallRepository() = runTest {
         // given
-        val validEmail = "test@test.com"
         val blankPassword = ""
 
         // when
-        val result = loginUseCase(validEmail, blankPassword)
+        val result = loginUseCase(UserFixtures.VALID_EMAIL, blankPassword)
 
         // then
         assertTrue(result.isFailure)
@@ -101,43 +97,40 @@ class LoginUCTest {
         coVerify(exactly = 0) { authRepository.login(any(), any()) }
     }
 
-    //Repository
+    //Repository Calls
 
     @Test
-    fun `valid credentials return Result success with AuthUser`() = runTest {
+    fun validCredentials_returnsResultSuccess_withAuthUser() = runTest {
         // given
-        val validEmail = "test@test.com"
-        val validPassword = "123456"
-        val fakeUser = AuthUser(uid = "123", email = validEmail)
-        coEvery { authRepository.login(validEmail, validPassword) } returns fakeUser
+        coEvery {
+            authRepository.login(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
+        } returns UserFixtures.fakeAuthUser
 
         // when
-        val result = loginUseCase(validEmail, validPassword)
+        val result = loginUseCase(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(
             "Expected success but got: ${result.exceptionOrNull()?.message}",
             result.isSuccess
         )
-        assertEquals(fakeUser, result.getOrNull())
-        coVerify(exactly = 1) { authRepository.login(validEmail, validPassword) }
+        assertEquals(UserFixtures.fakeAuthUser, result.getOrNull())
+        coVerify(exactly = 1) {
+            authRepository.login(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
+        }
     }
 
     @Test
-    fun `repository exception is caught and returned as Result failure`() = runTest {
+    fun invalidCredentials_returnsResultFailure_throwsFailure() = runTest {
         // given
-        val validEmail = "test@test.com"
-        val validPassword = "123456"
         val exception = Exception("Invalid credentials")
         coEvery { authRepository.login(any(), any()) } throws exception
 
         // when
-        val result = loginUseCase(validEmail, validPassword)
+        val result = loginUseCase(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)
         assertEquals(exception, result.exceptionOrNull())
     }
-
-
 }

--- a/app/src/test/java/com/oracle/visualize/usecases/RegisterUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/RegisterUCTest.kt
@@ -1,8 +1,8 @@
 package com.oracle.visualize.usecases
 
-import com.oracle.visualize.domain.models.AuthUser
 import com.oracle.visualize.domain.repositories.AuthRepository
 import com.oracle.visualize.domain.usecases.RegisterUseCase
+import com.oracle.visualize.fixtures.UserFixtures
 import io.mockk.coEvery
 import io.mockk.coVerify
 import junit.framework.TestCase.assertEquals
@@ -41,13 +41,12 @@ class RegisterUseCaseTest {
     //Email Validation
 
     @Test
-    fun `blank email returns ValidationError and does not call repository`() = runTest {
+    fun blankEmail_returnsValidationError_doesNotCallRepository() = runTest {
         // given
         val blankEmail = ""
-        val anyPassword = "123456"
 
         // when
-        val result = registerUseCase(blankEmail, anyPassword)
+        val result = registerUseCase(blankEmail, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)
@@ -56,13 +55,12 @@ class RegisterUseCaseTest {
     }
 
     @Test
-    fun `invalid email format returns ValidationError and does not call repository`() = runTest {
+    fun invalidEmailFormat_returnsValidationError_doesNotCallRepository() = runTest {
         // given
         val invalidEmail = "notanemail"
-        val anyPassword = "123456"
 
         // when
-        val result = registerUseCase(invalidEmail, anyPassword)
+        val result = registerUseCase(invalidEmail, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)
@@ -71,31 +69,28 @@ class RegisterUseCaseTest {
     }
 
     @Test
-    fun `email without TLD returns ValidationError and does not call repository`() = runTest {
+    fun emailWithoutTLD_returnsValidationError_doesNotCallRepository() = runTest {
         // given
         val emailWithoutTLD = "test@test"
-        val anyPassword = "123456"
 
         // when
-        val result = registerUseCase(emailWithoutTLD, anyPassword)
+        val result = registerUseCase(emailWithoutTLD, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is AppError.ValidationError)
         coVerify(exactly = 0) { authRepository.register(any(), any()) }
     }
-
 
     //Password Validation
 
     @Test
-    fun `blank password returns ValidationError and does not call repository`() = runTest {
+    fun blankPassword_returnsValidationError_doesNotCallRepository() = runTest {
         // given
-        val validEmail = "test@test.com"
         val blankPassword = ""
 
         // when
-        val result = registerUseCase(validEmail, blankPassword)
+        val result = registerUseCase(UserFixtures.VALID_EMAIL, blankPassword)
 
         // then
         assertTrue(result.isFailure)
@@ -104,13 +99,12 @@ class RegisterUseCaseTest {
     }
 
     @Test
-    fun `password shorter than 6 characters returns ValidationError and does not call repository`() = runTest {
+    fun passwordShorterThan6Chars_returnsValidationError_doesNotCallRepository() = runTest {
         // given
-        val validEmail = "test@test.com"
         val shortPassword = "12345" // 5 chars — boundary value just below minimum
 
         // when
-        val result = registerUseCase(validEmail, shortPassword)
+        val result = registerUseCase(UserFixtures.VALID_EMAIL, shortPassword)
 
         // then
         assertTrue(result.isFailure)
@@ -119,68 +113,62 @@ class RegisterUseCaseTest {
     }
 
     @Test
-    fun `password of exactly 6 characters passes validation and calls repository`() = runTest {
-        // given
-        val validEmail = "test@test.com"
-        val boundaryPassword = "123456" // exactly 6 chars — boundary value at minimum
-        val fakeUser = AuthUser(uid = "123", email = validEmail)
-        coEvery { authRepository.register(any(), any()) } returns fakeUser
+    fun passwordOfExactly6Chars_passesValidation_callsRepository() = runTest {
+        // given - boundary value: exactly at the minimum
+        coEvery { authRepository.register(any(), any()) } returns UserFixtures.fakeAuthUser
 
         // when
-        val result = registerUseCase(validEmail, boundaryPassword)
+        val result = registerUseCase(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isSuccess)
-        coVerify(exactly = 1) { authRepository.register(validEmail, boundaryPassword) }
+        coVerify(exactly = 1) {
+            authRepository.register(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
+        }
     }
 
     @Test
-    fun `password over 6 characters passes validation and calls repository`() = runTest {
-        // given
-        val validEmail = "test@test.com"
-        val boundaryPassword = "12345689400"
-        val fakeUser = AuthUser(uid = "123", email = validEmail)
-        coEvery { authRepository.register(any(), any()) } returns fakeUser
+    fun passwordOver6Chars_passesValidation_callsRepository() = runTest {
+        // given - boundary value: safely above minimum
+        val longPassword = "12345678900"
+        coEvery { authRepository.register(any(), any()) } returns UserFixtures.fakeAuthUser
 
         // when
-        val result = registerUseCase(validEmail, boundaryPassword)
+        val result = registerUseCase(UserFixtures.VALID_EMAIL, longPassword)
 
         // then
         assertTrue(result.isSuccess)
-        coVerify(exactly = 1) { authRepository.register(validEmail, boundaryPassword) }
+        coVerify(exactly = 1) { authRepository.register(UserFixtures.VALID_EMAIL, longPassword) }
     }
-
-
 
     //Repository
 
     @Test
-    fun `valid credentials return Result success with AuthUser`() = runTest {
+    fun validCredentials_returnsResultSuccess_withAuthUser() = runTest {
         // given
-        val validEmail = "test@test.com"
-        val validPassword = "123456"
-        val fakeUser = AuthUser(uid = "123", email = validEmail)
-        coEvery { authRepository.register(validEmail, validPassword) } returns fakeUser
+        coEvery {
+            authRepository.register(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
+        } returns UserFixtures.fakeAuthUser
 
         // when
-        val result = registerUseCase(validEmail, validPassword)
+        val result = registerUseCase(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isSuccess)
-        assertEquals(fakeUser, result.getOrNull())
-        coVerify(exactly = 1) { authRepository.register(validEmail, validPassword) }
+        assertEquals(UserFixtures.fakeAuthUser, result.getOrNull())
+        coVerify(exactly = 1) {
+            authRepository.register(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
+        }
     }
 
     @Test
-    fun `repository exception is caught and returned as Result failure`() = runTest {
+    fun repositoryThrows_returnsResultFailure() = runTest {
         // given
-        val validEmail = "test@test.com"
-        val validPassword = "123456"
         val exception = Exception("Email already in use")
         coEvery { authRepository.register(any(), any()) } throws exception
 
         // when
-        val result = registerUseCase(validEmail, validPassword)
+        val result = registerUseCase(UserFixtures.VALID_EMAIL, UserFixtures.VALID_PASSWORD)
 
         // then
         assertTrue(result.isFailure)

--- a/app/src/test/java/com/oracle/visualize/usecases/RegisterUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/RegisterUCTest.kt
@@ -1,0 +1,189 @@
+package com.oracle.visualize.usecases
+
+import com.oracle.visualize.domain.models.AuthUser
+import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.usecases.RegisterUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import com.oracle.visualize.domain.exceptions.AppError
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+
+
+/**
+ * Unit tests for [RegisterUseCase].
+ *
+ *   RegisterUseCase validates email and password before delegating to
+ *   [AuthRepository]. It wraps results in [Result] instead of throwing,
+ *   so we assert on Result.isSuccess / Result.isFailure and the specific
+ *   error type rather than catching exceptions.
+
+ */
+
+class RegisterUseCaseTest {
+
+    @MockK
+    private lateinit var authRepository: AuthRepository
+    private lateinit var registerUseCase: RegisterUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        registerUseCase = RegisterUseCase(authRepository)
+    }
+
+
+    //Email Validation
+
+    @Test
+    fun `blank email returns ValidationError and does not call repository`() = runTest {
+        // given
+        val blankEmail = ""
+        val anyPassword = "123456"
+
+        // when
+        val result = registerUseCase(blankEmail, anyPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.register(any(), any()) }
+    }
+
+    @Test
+    fun `invalid email format returns ValidationError and does not call repository`() = runTest {
+        // given
+        val invalidEmail = "notanemail"
+        val anyPassword = "123456"
+
+        // when
+        val result = registerUseCase(invalidEmail, anyPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.register(any(), any()) }
+    }
+
+    @Test
+    fun `email without TLD returns ValidationError and does not call repository`() = runTest {
+        // given
+        val emailWithoutTLD = "test@test"
+        val anyPassword = "123456"
+
+        // when
+        val result = registerUseCase(emailWithoutTLD, anyPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.register(any(), any()) }
+    }
+
+
+    //Password Validation
+
+    @Test
+    fun `blank password returns ValidationError and does not call repository`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val blankPassword = ""
+
+        // when
+        val result = registerUseCase(validEmail, blankPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.register(any(), any()) }
+    }
+
+    @Test
+    fun `password shorter than 6 characters returns ValidationError and does not call repository`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val shortPassword = "12345" // 5 chars — boundary value just below minimum
+
+        // when
+        val result = registerUseCase(validEmail, shortPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AppError.ValidationError)
+        coVerify(exactly = 0) { authRepository.register(any(), any()) }
+    }
+
+    @Test
+    fun `password of exactly 6 characters passes validation and calls repository`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val boundaryPassword = "123456" // exactly 6 chars — boundary value at minimum
+        val fakeUser = AuthUser(uid = "123", email = validEmail)
+        coEvery { authRepository.register(any(), any()) } returns fakeUser
+
+        // when
+        val result = registerUseCase(validEmail, boundaryPassword)
+
+        // then
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { authRepository.register(validEmail, boundaryPassword) }
+    }
+
+    @Test
+    fun `password over 6 characters passes validation and calls repository`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val boundaryPassword = "12345689400"
+        val fakeUser = AuthUser(uid = "123", email = validEmail)
+        coEvery { authRepository.register(any(), any()) } returns fakeUser
+
+        // when
+        val result = registerUseCase(validEmail, boundaryPassword)
+
+        // then
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { authRepository.register(validEmail, boundaryPassword) }
+    }
+
+
+
+    //Repository
+
+    @Test
+    fun `valid credentials return Result success with AuthUser`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val validPassword = "123456"
+        val fakeUser = AuthUser(uid = "123", email = validEmail)
+        coEvery { authRepository.register(validEmail, validPassword) } returns fakeUser
+
+        // when
+        val result = registerUseCase(validEmail, validPassword)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(fakeUser, result.getOrNull())
+        coVerify(exactly = 1) { authRepository.register(validEmail, validPassword) }
+    }
+
+    @Test
+    fun `repository exception is caught and returned as Result failure`() = runTest {
+        // given
+        val validEmail = "test@test.com"
+        val validPassword = "123456"
+        val exception = Exception("Email already in use")
+        coEvery { authRepository.register(any(), any()) } throws exception
+
+        // when
+        val result = registerUseCase(validEmail, validPassword)
+
+        // then
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}

--- a/app/src/test/java/com/oracle/visualize/usecases/ValidateDatasetUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/ValidateDatasetUCTest.kt
@@ -1,0 +1,154 @@
+package com.oracle.visualize.usecases
+
+import com.oracle.visualize.domain.usecases.ValidateDatasetUseCase
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [ValidateDatasetUseCase].
+ *
+ *   Has no repository dependency.
+ */
+
+class ValidateDatasetUCTest {
+    private val validateDataset = ValidateDatasetUseCase()
+
+    //Extension validation
+
+    @Test
+    fun `csv file with valid size returns success`() {
+        // given
+        val fileName = "data.csv"
+        val validSize = 1 * 1024 * 1024L // 1 MB
+
+        // when
+        val result = validateDataset(fileName, validSize)
+
+        // then
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `xlsx file with valid size returns success`() {
+        // given
+        val fileName = "data.xlsx"
+        val validSize = 1 * 1024 * 1024L // 1 MB
+
+        // when
+        val result = validateDataset(fileName, validSize)
+
+        // then
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `unsupported extension returns IllegalArgumentException`() {
+        // given
+        val fileName = "data.pdf"
+        val validSize = 1 * 1024 * 1024L // 1 MB
+
+        // when
+        val result = validateDataset(fileName, validSize)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `no extension returns IllegalArgumentException`() {
+        // given
+        val fileName = "datafile"
+        val validSize = 1 * 1024 * 1024L
+
+        // when
+        val result = validateDataset(fileName, validSize)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `uppercase extension is accepted`() {
+        // given - extension is lowercased internally via lowercase(Locale.ROOT)
+        val fileName = "data.CSV"
+        val validSize = 1 * 1024 * 1024L
+
+        // when
+        val result = validateDataset(fileName, validSize)
+
+        // then
+        assertTrue(result.isSuccess)
+    }
+
+    //Size Validation
+
+    @Test
+    fun `csv file at exactly 100 MB returns success`() {
+        // given
+        val fileName = "data.csv"
+        val exactLimit = 100 * 1024 * 1024L // exactly 100 MB
+
+        // when
+        val result = validateDataset(fileName, exactLimit)
+
+        // then
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `xlsx file at exactly 100 MB returns success`() {
+        // given
+        val fileName = "data.xlsx"
+        val exactLimit = 100 * 1024 * 1024L // exactly 100 MB
+
+        // when
+        val result = validateDataset(fileName, exactLimit)
+
+        // then
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `file one byte over 100 MB returns IllegalArgumentException`() {
+        // given
+        val fileName = "data.csv"
+        val oneByteOver = (100 * 1024 * 1024L) + 1
+
+        // when
+        val result = validateDataset(fileName, oneByteOver)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `file 100 bytes over 100 MB returns IllegalArgumentException`() {
+        // given
+        val fileName = "data.csv"
+        val oneByteOver = (100 * 1024 * 1024L) + 100
+
+        // when
+        val result = validateDataset(fileName, oneByteOver)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `empty file returns failure`() {
+        // given
+        val fileName = "data.csv"
+        val emptyFile = 0L
+
+        // when
+        val result = validateDataset(fileName, emptyFile)
+
+        // then
+        assertTrue(result.isFailure)
+    }
+
+}

--- a/app/src/test/java/com/oracle/visualize/usecases/ValidateDatasetUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/ValidateDatasetUCTest.kt
@@ -1,6 +1,7 @@
 package com.oracle.visualize.usecases
 
 import com.oracle.visualize.domain.usecases.ValidateDatasetUseCase
+import com.oracle.visualize.fixtures.DatasetFixtures
 import junit.framework.TestCase.assertTrue
 import org.junit.Test
 
@@ -16,39 +17,36 @@ class ValidateDatasetUCTest {
     //Extension validation
 
     @Test
-    fun `csv file with valid size returns success`() {
+    fun csvFile_withValidSize_returnsSuccess() {
         // given
-        val fileName = "data.csv"
-        val validSize = 1 * 1024 * 1024L // 1 MB
+        val validSize = DatasetFixtures.VALID_SIZE
 
         // when
-        val result = validateDataset(fileName, validSize)
+        val result = validateDataset(DatasetFixtures.VALID_CSV_NAME, validSize)
 
         // then
         assertTrue(result.isSuccess)
     }
 
     @Test
-    fun `xlsx file with valid size returns success`() {
+    fun xlsxFile_withValidSize_returnsSuccess() {
         // given
-        val fileName = "data.xlsx"
-        val validSize = 1 * 1024 * 1024L // 1 MB
+        val validSize = DatasetFixtures.VALID_SIZE
 
         // when
-        val result = validateDataset(fileName, validSize)
+        val result = validateDataset(DatasetFixtures.VALID_XLSX_NAME, validSize)
 
         // then
         assertTrue(result.isSuccess)
     }
 
     @Test
-    fun `unsupported extension returns IllegalArgumentException`() {
+    fun unsupportedExtension_returnsIllegalArgumentException() {
         // given
-        val fileName = "data.pdf"
-        val validSize = 1 * 1024 * 1024L // 1 MB
+        val unsupportedFile = "data.pdf"
 
         // when
-        val result = validateDataset(fileName, validSize)
+        val result = validateDataset(unsupportedFile, DatasetFixtures.VALID_SIZE)
 
         // then
         assertTrue(result.isFailure)
@@ -56,13 +54,12 @@ class ValidateDatasetUCTest {
     }
 
     @Test
-    fun `no extension returns IllegalArgumentException`() {
+    fun noExtension_returnsIllegalArgumentException() {
         // given
-        val fileName = "datafile"
-        val validSize = 1 * 1024 * 1024L
+        val noExtensionFile = "datafile"
 
         // when
-        val result = validateDataset(fileName, validSize)
+        val result = validateDataset(noExtensionFile, DatasetFixtures.VALID_SIZE)
 
         // then
         assertTrue(result.isFailure)
@@ -70,13 +67,25 @@ class ValidateDatasetUCTest {
     }
 
     @Test
-    fun `uppercase extension is accepted`() {
+    fun blankFileName_returnsIllegalArgumentException() {
+        // given
+        val blankFileName = ""
+
+        // when
+        val result = validateDataset(blankFileName, DatasetFixtures.VALID_SIZE)
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun uppercaseExtension_isAccepted_returnsSuccess() {
         // given - extension is lowercased internally via lowercase(Locale.ROOT)
-        val fileName = "data.CSV"
-        val validSize = 1 * 1024 * 1024L
+        val uppercaseExtension = "data.CSV"
 
         // when
-        val result = validateDataset(fileName, validSize)
+        val result = validateDataset(uppercaseExtension, DatasetFixtures.VALID_SIZE)
 
         // then
         assertTrue(result.isSuccess)
@@ -85,39 +94,30 @@ class ValidateDatasetUCTest {
     //Size Validation
 
     @Test
-    fun `csv file at exactly 100 MB returns success`() {
-        // given
-        val fileName = "data.csv"
-        val exactLimit = 100 * 1024 * 1024L // exactly 100 MB
-
-        // when
-        val result = validateDataset(fileName, exactLimit)
+    fun csvFile_atExactly100MB_returnsSuccess() {
+        // given - boundary size: exactly at the limit
+        val result = validateDataset(DatasetFixtures.VALID_CSV_NAME, DatasetFixtures.MAX_SIZE)
 
         // then
         assertTrue(result.isSuccess)
     }
 
     @Test
-    fun `xlsx file at exactly 100 MB returns success`() {
-        // given
-        val fileName = "data.xlsx"
-        val exactLimit = 100 * 1024 * 1024L // exactly 100 MB
-
-        // when
-        val result = validateDataset(fileName, exactLimit)
+    fun xlsxFile_atExactly100MB_returnsSuccess() {
+        // given - size: exactly at the limit
+        val result = validateDataset(DatasetFixtures.VALID_XLSX_NAME, DatasetFixtures.MAX_SIZE)
 
         // then
         assertTrue(result.isSuccess)
     }
 
     @Test
-    fun `file one byte over 100 MB returns IllegalArgumentException`() {
+    fun file_oneByteOver100MB_returnsIllegalArgumentException() {
         // given
-        val fileName = "data.csv"
-        val oneByteOver = (100 * 1024 * 1024L) + 1
+        val oneByteOver = DatasetFixtures.MAX_SIZE + 1
 
         // when
-        val result = validateDataset(fileName, oneByteOver)
+        val result = validateDataset(DatasetFixtures.VALID_CSV_NAME, oneByteOver)
 
         // then
         assertTrue(result.isFailure)
@@ -125,13 +125,12 @@ class ValidateDatasetUCTest {
     }
 
     @Test
-    fun `file 100 bytes over 100 MB returns IllegalArgumentException`() {
+    fun file_100BytesOver100MB_returnsIllegalArgumentException() {
         // given
-        val fileName = "data.csv"
-        val oneByteOver = (100 * 1024 * 1024L) + 100
+        val hundredBytesOver = DatasetFixtures.MAX_SIZE + 100
 
         // when
-        val result = validateDataset(fileName, oneByteOver)
+        val result = validateDataset(DatasetFixtures.VALID_CSV_NAME, hundredBytesOver)
 
         // then
         assertTrue(result.isFailure)
@@ -139,16 +138,16 @@ class ValidateDatasetUCTest {
     }
 
     @Test
-    fun `empty file returns failure`() {
+    fun emptyFile_returnsIllegalArgumentException() {
         // given
-        val fileName = "data.csv"
         val emptyFile = 0L
 
         // when
-        val result = validateDataset(fileName, emptyFile)
+        val result = validateDataset(DatasetFixtures.VALID_CSV_NAME, emptyFile)
 
         // then
         assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ coil = "3.4.0"
 koalaplot = "0.11.0"
 mockk = "1.13.12"
 foundationLayout = "1.11.0"
+coroutinesTest = "1.10.2"
 
 
 [libraries]
@@ -59,6 +60,7 @@ coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp"
 koalaplot-core = { group = "io.github.koalaplot", name = "koalaplot-core", version.ref = "koalaplot" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 
 
 


### PR DESCRIPTION
Added unit tests for the domain layer use cases:
- GetAllUserVisualizationsUseCase
- GetUserSuggestionsUseCase
- LoginUseCase
- LogoutUseCase
- RegisterUseCase
- ValidateDatasetUseCase

Added kotlinx-coroutines-test to support testing suspend functions in repository-dependent use cases.

**Note**
Testing revealed that ValidateDatasetUseCase does not reject empty files (0 bytes) or blank filenames. This will be addressed in a
separate PR.