### PR TITLE
Fix: Team-shared visualizations feed and Clean Architecture refactor

### DIFF
--- a/app/src/main/java/com/oracle/visualize/data/datasources/AuthFirebasesource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/AuthFirebasesource.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
  *
  * @property auth The [FirebaseAuth] instance used for authentication operations.
  */
-class AuthFirebaseSource @Inject constructor(private val auth: FirebaseAuth) {
+class AuthFirebasesource @Inject constructor(private val auth: FirebaseAuth) {
     /**
      * Attempts to log in a user with the provided email and password.
      *

--- a/app/src/main/java/com/oracle/visualize/data/datasources/TeamDatasource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/TeamDatasource.kt
@@ -1,5 +1,6 @@
 package com.oracle.visualize.data.datasources
 
+import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.FirebaseFirestore
 import com.oracle.visualize.data.datasources.dtos.TeamDTO
 import com.oracle.visualize.domain.exceptions.AppError
@@ -102,5 +103,15 @@ class TeamDatasource @Inject constructor(
             if (ex is AppError) throw ex
             throw AppError.NetworkError("Failed to fetch user's teams: ${ex.message}")
         }
+    }
+
+    suspend fun getTeamsByIDs(ids: List<String>): List<TeamDTO> {
+        if (ids.isEmpty()) return emptyList()
+
+        val snapshot = db.collection("teams")
+            .whereIn(FieldPath.documentId(), ids)
+            .get()
+            .await()
+        return snapshot.toObjects(TeamDTO::class.java)
     }
 }

--- a/app/src/main/java/com/oracle/visualize/data/datasources/TeamDatasource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/TeamDatasource.kt
@@ -3,6 +3,7 @@ package com.oracle.visualize.data.datasources
 import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.FirebaseFirestore
 import com.oracle.visualize.data.datasources.dtos.TeamDTO
+import com.oracle.visualize.data.datasources.dtos.VisualizationDTO
 import com.oracle.visualize.domain.exceptions.AppError
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -98,7 +99,12 @@ class TeamDatasource @Inject constructor(
     suspend fun getTeamsUserIsIn(userID: String): List<TeamDTO> {
         return try {
             val snapshot = teamsRef.whereArrayContains("membersIDs", userID).get().await()
-            snapshot.toObjects(TeamDTO::class.java)
+            if (snapshot.isEmpty) return emptyList()
+
+            snapshot.documents.map { doc ->
+                doc.toObject(TeamDTO::class.java)
+                    ?: throw AppError.ParsingError("Failed to parse TeamDTO: ${doc.id}")
+            }
         } catch (ex: Exception) {
             if (ex is AppError) throw ex
             throw AppError.NetworkError("Failed to fetch user's teams: ${ex.message}")
@@ -107,11 +113,18 @@ class TeamDatasource @Inject constructor(
 
     suspend fun getTeamsByIDs(ids: List<String>): List<TeamDTO> {
         if (ids.isEmpty()) return emptyList()
-
-        val snapshot = db.collection("teams")
-            .whereIn(FieldPath.documentId(), ids)
-            .get()
-            .await()
-        return snapshot.toObjects(TeamDTO::class.java)
+        return try {
+            val snapshot = db.collection("teams")
+                .whereIn(FieldPath.documentId(), ids)
+                .get()
+                .await()
+            snapshot.documents.map { doc ->
+                doc.toObject(TeamDTO::class.java)
+                    ?: throw AppError.ParsingError("Failed to parse TeamDTO: ${doc.id}")
+            }
+        } catch (ex: Exception) {
+            if (ex is AppError) throw ex
+            throw AppError.NetworkError("Failed to fetch user's teams: ${ex.message}")
+        }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/data/datasources/UserDatasource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/UserDatasource.kt
@@ -48,23 +48,6 @@ class UserDatasource @Inject constructor(
     }
 
     /**
-     * Fetches teams that the specified user is a member of.
-     *
-     * @param userID The unique ID of the user.
-     * @return A list of [TeamDTO] objects.
-     * @throws AppError.NetworkError If a network error occurs.
-     */
-    suspend fun getTeamsIntegratedByUser(userID: String): List<TeamDTO> {
-        return try {
-            val snapshot = firestore.collection("teams").whereArrayContains("memberIDs", userID).get().await()
-            snapshot.toObjects(TeamDTO::class.java)
-        } catch (ex: Exception) {
-            if (ex is AppError) throw ex
-            throw AppError.NetworkError("Error fetching integrated teams: ${ex.message}")
-        }
-    }
-
-    /**
      * Fetches user suggestions based on a partial email address.
      *
      * @param email The partial email string to search for.

--- a/app/src/main/java/com/oracle/visualize/data/datasources/UserDatasource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/UserDatasource.kt
@@ -1,5 +1,6 @@
 package com.oracle.visualize.data.datasources
 
+import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.FirebaseFirestore
 import com.oracle.visualize.data.datasources.dtos.TeamDTO
 import com.oracle.visualize.data.datasources.dtos.UserDTO
@@ -90,24 +91,13 @@ class UserDatasource @Inject constructor(
         }
     }
 
-    /**
-     * Fetches groups (teams) that the specified user is in.
-     * Note: Uses "groups" collection; verify if it should be "teams".
-     *
-     * @param userID The unique ID of the user.
-     * @return A list of [TeamDTO] objects.
-     * @throws AppError.NetworkError If a network error occurs.
-     */
-    suspend fun getTeamsUserIsIn(userID: String): List<TeamDTO> {
-        return try {
-            val snapshot = firestore.collection("groups")
-                .whereArrayContains("membersID", userID)
-                .get()
-                .await()
-            snapshot.toObjects(TeamDTO::class.java)
-        } catch (e: Exception) {
-            if (e is AppError) throw e
-            throw AppError.NetworkError("Error fetching user groups: ${e.message}")
-        }
+    suspend fun getUsersByIDs(ids: List<String>): List<UserDTO> {
+        if (ids.isEmpty()) return emptyList()
+
+        val snapshot = firestore.collection("users")
+            .whereIn(FieldPath.documentId(), ids)
+            .get()
+            .await()
+        return snapshot.toObjects(UserDTO::class.java)
     }
 }

--- a/app/src/main/java/com/oracle/visualize/data/datasources/VisualizationDataSource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/VisualizationDataSource.kt
@@ -17,10 +17,10 @@ import javax.inject.Inject
  * @property db The [FirebaseFirestore] instance used for database operations.
  */
 class VisualizationDataSource @Inject constructor(
-    private val db: FirebaseFirestore
+    private val db: FirebaseFirestore,
+    private val teamsDatasource: TeamDatasource
 ) {
     private val visualizationsRef = db.collection("visualizations")
-    private val teamsRef = db.collection("teams")
 
     /**
      * Creates a new visualization in the database.
@@ -86,7 +86,8 @@ class VisualizationDataSource @Inject constructor(
         return try {
             val visualizations = visualizationsRef
                 .whereArrayContains("sharedWithUsers", userID)
-                .get().await()
+                .get()
+                .await()
 
             if (visualizations.isEmpty) return emptyList()
 
@@ -126,109 +127,24 @@ class VisualizationDataSource @Inject constructor(
         }
     }
 
-    /**
-     * Fetches visualizations shared with any team that the user is a member of.
-     *
-     * @param userID The unique ID of the user.
-     * @return A list of [VisualizationDTO] objects shared with the user's teams.
-     * @throws AppError.ParsingError If any document cannot be parsed.
-     * @throws AppError.NetworkError If a network error occurs.
-     */
-    suspend fun getSharedVisualizationsByTeamsIntegratedByUser(userID: String): List<VisualizationDTO> {
-        return try {
-            val teams = teamsRef.whereArrayContains("membersIDs", userID).get().await()
-            val teamIDs = teams.documents.map { it.id }
+    private suspend fun getVisualizationsSharedWithTeamsUserIsIn(userID: String): List<VisualizationDTO> {
+        val userTeams = teamsDatasource.getTeamsUserIsIn(userID)
+        val teamIDs = userTeams.mapNotNull { it.id }
 
-            if (teamIDs.isEmpty()) return emptyList()
+        if (teamIDs.isEmpty()) return emptyList()
 
-            val sharedWithTeams = visualizationsRef
-                .whereArrayContainsAny("sharedWithTeams", teamIDs)
-                .get()
-                .await()
-
-            if (sharedWithTeams.isEmpty) return emptyList()
-
-            sharedWithTeams.documents.map { doc ->
-                doc.toObject(VisualizationDTO::class.java)
-                    ?: throw AppError.ParsingError("Failed to parse VisualizationDTO: ${doc.id}")
-            }
-        } catch (ex: Exception) {
-            if (ex is AppError) throw ex
-            throw AppError.NetworkError("Failed to fetch team visualizations: ${ex.message}")
-        }
+        val snapshot = db.collection("visualizations")
+            .whereArrayContainsAny("sharedWithTeams", teamIDs)
+            .get()
+            .await()
+        return snapshot.toObjects(VisualizationDTO::class.java)
     }
 
-    /**
-     * Aggregates all visualizations relevant to a user (personal, shared with user, shared with teams).
-     *
-     * @param userID The unique ID of the user.
-     * @return A list of [VisualizationDTO] objects.
-     * @throws AppError.NetworkError If a network error occurs.
-     */
-    suspend fun getAllVisualizationsByUserID(userID: String): List<VisualizationDTO> {
-        return try {
-            val finalArray = mutableListOf<VisualizationDTO>()
-            val personal = getPersonalVisualizations(userID)
-            val sharedWithUsers = getVisualizationsSharedWithUser(userID)
-            val sharedWithTeams = getSharedVisualizationsByTeamsIntegratedByUser(userID)
+    suspend fun getAllSharedVisualizations(userID: String): List<VisualizationDTO> {
+        val sharedWithUser = getVisualizationsSharedWithUser(userID)
+        val sharedWithTeams = getVisualizationsSharedWithTeamsUserIsIn(userID)
 
-            finalArray.addAll(personal)
-            finalArray.addAll(sharedWithUsers)
-            finalArray.addAll(sharedWithTeams)
-            finalArray
-        } catch (ex: Exception) {
-            if (ex is AppError) throw ex
-            throw AppError.NetworkError("Failed to aggregate visualizations: ${ex.message}")
-        }
-    }
-
-    /**
-     * Fetches all users that a specific visualization is shared with.
-     *
-     * @param visualizationID The unique ID of the visualization.
-     * @return A list of [UserDTO] objects representing the users.
-     * @throws AppError.NotFound If the visualization ID does not exist.
-     * @throws AppError.ParsingError If documentation mapping fails.
-     * @throws AppError.NetworkError If a network error occurs.
-     */
-    suspend fun getAllUsersVisualizationIsSharedWith(visualizationID: String): List<UserDTO> {
-        return try {
-            val snapshot = db.collection("visualizations")
-                .document(visualizationID)
-                .get()
-                .await()
-
-            if (!snapshot.exists()) {
-                throw AppError.NotFound("This visualization ID does not exist.")
-            }
-
-            val visualizationDTO = snapshot.toObject(VisualizationDTO::class.java)
-                ?: throw AppError.ParsingError("Visualization could not be mapped.")
-
-            val sharedUserIDs = visualizationDTO.sharedWithUsers.filter { it.isNotBlank() }
-
-            coroutineScope {
-                sharedUserIDs.map { userId ->
-                    async {
-                        val userSnapshot = db.collection("users")
-                            .document(userId)
-                            .get()
-                            .await()
-
-                        if (userSnapshot.exists()) {
-                            userSnapshot.toObject(UserDTO::class.java)
-                                ?: throw AppError.ParsingError("Failed to map UserDTO: $userId")
-                        } else {
-                            null
-                        }
-                    }
-                }
-                    .awaitAll()
-                    .filterNotNull()
-            }
-        } catch (ex: Exception) {
-            if (ex is AppError) throw ex
-            throw AppError.NetworkError("Failed to fetch shared users: ${ex.message}")
-        }
+        val allShared = sharedWithUser + sharedWithTeams
+        return allShared.distinctBy { it.id }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/data/datasources/VisualizationDatasource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/VisualizationDatasource.kt
@@ -1,13 +1,9 @@
 package com.oracle.visualize.data.datasources
 
 import com.google.firebase.firestore.FirebaseFirestore
-import com.oracle.visualize.data.datasources.dtos.UserDTO
 import com.oracle.visualize.data.datasources.dtos.VisualizationDTO
 import com.oracle.visualize.domain.exceptions.AppError
 import com.oracle.visualize.domain.models.Visualization
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -16,7 +12,7 @@ import javax.inject.Inject
  *
  * @property db The [FirebaseFirestore] instance used for database operations.
  */
-class VisualizationDataSource @Inject constructor(
+class VisualizationDatasource @Inject constructor(
     private val db: FirebaseFirestore,
     private val teamsDatasource: TeamDatasource
 ) {
@@ -128,23 +124,39 @@ class VisualizationDataSource @Inject constructor(
     }
 
     private suspend fun getVisualizationsSharedWithTeamsUserIsIn(userID: String): List<VisualizationDTO> {
-        val userTeams = teamsDatasource.getTeamsUserIsIn(userID)
-        val teamIDs = userTeams.mapNotNull { it.id }
+        return try {
+            val userTeams = teamsDatasource.getTeamsUserIsIn(userID)
+            val teamIDs = userTeams.mapNotNull { it.id }
 
-        if (teamIDs.isEmpty()) return emptyList()
+            if (teamIDs.isEmpty()) return emptyList()
 
-        val snapshot = db.collection("visualizations")
-            .whereArrayContainsAny("sharedWithTeams", teamIDs)
-            .get()
-            .await()
-        return snapshot.toObjects(VisualizationDTO::class.java)
+            val snapshot = db.collection("visualizations")
+                .whereArrayContainsAny("sharedWithTeams", teamIDs)
+                .get()
+                .await()
+
+            if (snapshot.isEmpty) return emptyList()
+
+            snapshot.documents.map { doc ->
+                doc.toObject(VisualizationDTO::class.java)
+                    ?: throw AppError.ParsingError("Failed to parse VisualizationDTO: ${doc.id}")
+            }
+        } catch (ex: Exception) {
+            if (ex is AppError) throw ex
+            throw AppError.NetworkError("Error fetching team visualizations: ${ex.message}")
+        }
     }
 
     suspend fun getAllSharedVisualizations(userID: String): List<VisualizationDTO> {
-        val sharedWithUser = getVisualizationsSharedWithUser(userID)
-        val sharedWithTeams = getVisualizationsSharedWithTeamsUserIsIn(userID)
+        return try {
+            val sharedWithUser = getVisualizationsSharedWithUser(userID)
+            val sharedWithTeams = getVisualizationsSharedWithTeamsUserIsIn(userID)
 
-        val allShared = sharedWithUser + sharedWithTeams
-        return allShared.distinctBy { it.id }
+            val allShared = sharedWithUser + sharedWithTeams
+            allShared.distinctBy { it.id }
+        } catch (ex: Exception) {
+            if (ex is AppError) throw ex
+            throw AppError.NetworkError("Error fetching all shared visualizations: ${ex.message}")
+        }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/data/mapper/TeamMappers.kt
+++ b/app/src/main/java/com/oracle/visualize/data/mapper/TeamMappers.kt
@@ -2,15 +2,16 @@ package com.oracle.visualize.data.mapper
 
 import com.oracle.visualize.data.datasources.dtos.TeamDTO
 import com.oracle.visualize.domain.models.Team
+import com.oracle.visualize.domain.models.User
 
 /**
  * Extension function to map [TeamDTO] to [Team] domain model.
  *
  * @return A [Team] object containing the same data as the DTO.
  */
-fun TeamDTO.toDomain(): Team = Team(
+fun TeamDTO.toDomain(members: List<User>): Team = Team(
     id = id,
-    memberIDs = membersIDs,
+    members = members,
     name = name,
     ownerID = ownerID
 )

--- a/app/src/main/java/com/oracle/visualize/data/mapper/VisualizationMappers.kt
+++ b/app/src/main/java/com/oracle/visualize/data/mapper/VisualizationMappers.kt
@@ -1,6 +1,9 @@
 package com.oracle.visualize.data.mapper
 
 import com.oracle.visualize.data.datasources.dtos.VisualizationDTO
+import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.domain.models.ShareUser
+import com.oracle.visualize.domain.models.Team
 import com.oracle.visualize.domain.models.User
 import com.oracle.visualize.domain.models.Visualization
 import com.oracle.visualize.domain.models.VisualizationCard
@@ -28,13 +31,32 @@ fun VisualizationDTO.toDomain(): Visualization = Visualization(
  * @param sharedUsers List of [User] objects representing who the visualization is shared with.
  * @return A [VisualizationCard] object.
  */
-fun VisualizationDTO.toVisualizationCard(authorName: String, sharedUsers: List<User>): VisualizationCard {
+fun VisualizationDTO.toVisualizationCard(
+    authorName: String,
+    teamsSharedWith: List<Team>,
+    usersSharedWith: List<User>): VisualizationCard {
+    val allUsersDict = mutableMapOf<String, User>()
+
+    for (user in usersSharedWith) {
+        allUsersDict[user.id] = user
+    }
+
+    for (team in teamsSharedWith) {
+        for (member in team.members) {
+            allUsersDict[member.id] = member
+        }
+    }
+
+    val allUsers = allUsersDict.values.toList()
+
     return VisualizationCard(
-        id = this.id,
+        id = this.id ?: "",
         title = this.title,
         author = authorName,
         createdAt = this.createdAt.toDate(),
         configJSON = this.configJSON,
-        sharedWith = sharedUsers
+        teamsSharedWith = teamsSharedWith,
+        usersSharedWith = usersSharedWith,
+        allUsersSharedWith = allUsers
     )
 }

--- a/app/src/main/java/com/oracle/visualize/data/repositories/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/AuthRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.oracle.visualize.data.repositories
 
-import com.oracle.visualize.data.datasources.AuthFirebaseSource
+import com.oracle.visualize.data.datasources.AuthFirebasesource
 import com.oracle.visualize.data.mapper.toDomain
 import com.oracle.visualize.domain.models.AuthUser
 import com.oracle.visualize.domain.repositories.AuthRepository
@@ -9,9 +9,9 @@ import javax.inject.Inject
 /**
  * Implementation of [AuthRepository] using Firebase Authentication.
  *
- * @property source The [AuthFirebaseSource] to interact with Firebase Auth.
+ * @property source The [AuthFirebasesource] to interact with Firebase Auth.
  */
-class AuthRepositoryImpl @Inject constructor(private val source: AuthFirebaseSource): AuthRepository {
+class AuthRepositoryImpl @Inject constructor(private val source: AuthFirebasesource): AuthRepository {
     override suspend fun login(email: String, password: String): AuthUser {
         return source.login(email,password).toDomain()
     }

--- a/app/src/main/java/com/oracle/visualize/data/repositories/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/UserRepositoryImpl.kt
@@ -29,13 +29,5 @@ class UserRepositoryImpl @Inject constructor(
             deferredUsers.awaitAll()
         }
     }
-
-    override suspend fun getUserByUserID(userId: String): User {
-        return userDatasource.getUserByID(userId).toDomain()
-    }
-
-    override suspend fun getTeamsIntegratedByUser(userId: String): List<Team> {
-        return userDatasource.getTeamsIntegratedByUser(userId).map { it.toDomain() }
-    }
 }
 

--- a/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
@@ -54,7 +54,7 @@ class VisualizationRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getSharedVisualizations(userID: String): List<VisualizationCard> {
-        val dtos = visualizationDataSource.getVisualizationsSharedWithUser(userID)
+        val dtos = visualizationDataSource.getAllSharedVisualizations(userID)
         return fetchDetailsAndMap(dtos)
     }
 

--- a/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
@@ -2,30 +2,26 @@ package com.oracle.visualize.data.repositories
 
 import com.oracle.visualize.data.datasources.TeamDatasource
 import com.oracle.visualize.data.datasources.UserDatasource
-import com.oracle.visualize.data.datasources.VisualizationDataSource
+import com.oracle.visualize.data.datasources.VisualizationDatasource
 import com.oracle.visualize.data.datasources.dtos.VisualizationDTO
 import com.oracle.visualize.data.mapper.toDomain
-import com.oracle.visualize.data.mapper.toShareTeam
-import com.oracle.visualize.data.mapper.toShareUser
 import com.oracle.visualize.data.mapper.toVisualizationCard
 import com.oracle.visualize.domain.models.Visualization
 import com.oracle.visualize.domain.models.VisualizationCard
-import com.oracle.visualize.domain.models.enums.VisualizationFilter
 import com.oracle.visualize.domain.repositories.VisualizationRepository
-import kotlinx.coroutines.coroutineScope
 import java.util.Date
 import javax.inject.Inject
 
 /**
  * Implementation of [VisualizationRepository] that manages visualization data.
- * It combines data from [VisualizationDataSource] and [UserDatasource] to create
+ * It combines data from [VisualizationDatasource] and [UserDatasource] to create
  * comprehensive [VisualizationCard] objects for the UI.
  *
  * @property visualizationDataSource Data source for visualization operations.
  * @property userDatasource Data source for user information.
  */
 class VisualizationRepositoryImpl @Inject constructor(
-    private val visualizationDataSource: VisualizationDataSource,
+    private val visualizationDataSource: VisualizationDatasource,
     private val userDatasource: UserDatasource,
     private val teamsDatasource: TeamDatasource
 ) : VisualizationRepository {

--- a/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
@@ -1,14 +1,18 @@
 package com.oracle.visualize.data.repositories
 
+import com.oracle.visualize.data.datasources.TeamDatasource
 import com.oracle.visualize.data.datasources.UserDatasource
 import com.oracle.visualize.data.datasources.VisualizationDataSource
 import com.oracle.visualize.data.datasources.dtos.VisualizationDTO
 import com.oracle.visualize.data.mapper.toDomain
+import com.oracle.visualize.data.mapper.toShareTeam
+import com.oracle.visualize.data.mapper.toShareUser
 import com.oracle.visualize.data.mapper.toVisualizationCard
 import com.oracle.visualize.domain.models.Visualization
 import com.oracle.visualize.domain.models.VisualizationCard
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
 import com.oracle.visualize.domain.repositories.VisualizationRepository
+import kotlinx.coroutines.coroutineScope
 import java.util.Date
 import javax.inject.Inject
 
@@ -22,7 +26,8 @@ import javax.inject.Inject
  */
 class VisualizationRepositoryImpl @Inject constructor(
     private val visualizationDataSource: VisualizationDataSource,
-    private val userDatasource: UserDatasource
+    private val userDatasource: UserDatasource,
+    private val teamsDatasource: TeamDatasource
 ) : VisualizationRepository {
 
     override suspend fun createVisualization(
@@ -48,40 +53,45 @@ class VisualizationRepositoryImpl @Inject constructor(
         return visualizationDataSource.getAllVisualizations().map { it.toDomain() }
     }
 
-    override suspend fun getAllVisualizationsByUserID(userID: String, filter: VisualizationFilter): List<VisualizationCard> {
-        val dtos = mutableListOf<VisualizationDTO>()
+    override suspend fun getSharedVisualizations(userID: String): List<VisualizationCard> {
+        val dtos = visualizationDataSource.getVisualizationsSharedWithUser(userID)
+        return fetchDetailsAndMap(dtos)
+    }
 
-        when(filter) {
-            VisualizationFilter.ALL -> {
-                dtos += visualizationDataSource.getAllVisualizationsByUserID(userID)
-            }
+    override suspend fun getPersonalVisualizations(userID: String): List<VisualizationCard> {
+        val dtos = visualizationDataSource.getPersonalVisualizations(userID)
+        return fetchDetailsAndMap(dtos)
+    }
 
-            VisualizationFilter.SHARED -> {
-                val visualizationsSharedWithUser = visualizationDataSource.getVisualizationsSharedWithUser(userID)
-                val visualizationsSharedWithTeam = visualizationDataSource.getSharedVisualizationsByTeamsIntegratedByUser(userID)
-                dtos += visualizationsSharedWithUser
-                dtos += visualizationsSharedWithTeam
-            }
-
-            VisualizationFilter.PERSONAL -> {
-                dtos += visualizationDataSource.getPersonalVisualizations(userID)
-            }
-        }
-
-        val visualizationCards = mutableListOf<VisualizationCard>()
-        val user = userDatasource.getUserByID(userID)
-        val hiddenVisualizations = user.hiddenVisualizations
-
+    private suspend fun fetchDetailsAndMap(dtos: List<VisualizationDTO>): List<VisualizationCard> {
+        val cards = mutableListOf<VisualizationCard>()
         for (dto in dtos) {
-            val author = userDatasource.getUserByID(dto.authorID)
-            val users = visualizationDataSource.getAllUsersVisualizationIsSharedWith(dto.id)
-            val sharedUsers = users.map { it.toDomain() }
-            val card = dto.toVisualizationCard(author.username,sharedUsers)
-            visualizationCards += card
+            val authorDTO = userDatasource.getUserByID(dto.authorID)
+            val authorName = authorDTO.username
+
+            val usersDTOs = userDatasource.getUsersByIDs(dto.sharedWithUsers)
+            val usersSharedWith = usersDTOs.map { it.toDomain() }
+
+            val teamsDTOs = teamsDatasource.getTeamsByIDs(dto.sharedWithTeams)
+
+            val uniqueMemberIDs = teamsDTOs.flatMap { it.membersIDs }.toSet().toList()
+            val membersDTOs = userDatasource.getUsersByIDs(uniqueMemberIDs)
+            val allMembers = membersDTOs.map { it.toDomain() }
+
+            val teamsSharedWith = teamsDTOs.map { teamDTO ->
+                val specificTeamMembers = allMembers.filter { member ->
+                    teamDTO.membersIDs.contains(member.id)
+                }
+                teamDTO.toDomain(specificTeamMembers)
+            }
+
+            val card = dto.toVisualizationCard(
+                authorName = authorName,
+                teamsSharedWith = teamsSharedWith,
+                usersSharedWith = usersSharedWith
+            )
+            cards.add(card)
         }
-        val filteredCards = visualizationCards.filter { card ->
-            card.id !in hiddenVisualizations
-        }
-        return visualizationCards
+        return cards
     }
 }

--- a/app/src/main/java/com/oracle/visualize/di/AppModule.kt
+++ b/app/src/main/java/com/oracle/visualize/di/AppModule.kt
@@ -4,9 +4,9 @@ import com.google.firebase.Firebase
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 import com.google.firebase.auth.FirebaseAuth
-import com.oracle.visualize.data.datasources.AuthFirebaseSource
+import com.oracle.visualize.data.datasources.AuthFirebasesource
 import com.oracle.visualize.data.datasources.TeamDatasource
-import com.oracle.visualize.data.datasources.VisualizationDataSource
+import com.oracle.visualize.data.datasources.VisualizationDatasource
 import com.oracle.visualize.data.repositories.AuthRepositoryImpl
 import com.oracle.visualize.data.repositories.TeamRepositoryImpl
 import com.oracle.visualize.data.repositories.VisualizationRepositoryImpl
@@ -46,7 +46,7 @@ object FirebaseModule {
         FirebaseFirestore.getInstance()
 
     /**
-     * Provides a singleton instance of [AuthFirebaseSource].
+     * Provides a singleton instance of [AuthFirebasesource].
      *
      * @param auth The [FirebaseAuth] instance.
      */
@@ -54,10 +54,10 @@ object FirebaseModule {
     @Singleton
     fun provideAuthFirebaseSource(
         auth: FirebaseAuth
-    ): AuthFirebaseSource = AuthFirebaseSource(auth)
+    ): AuthFirebasesource = AuthFirebasesource(auth)
 
     /**
-     * Provides a singleton instance of [VisualizationDataSource].
+     * Provides a singleton instance of [VisualizationDatasource].
      *
      * @param db The [FirebaseFirestore] instance.
      */
@@ -66,7 +66,7 @@ object FirebaseModule {
     fun provideVisualizationDataSource(
         db: FirebaseFirestore,
         teamsDatasource: TeamDatasource
-    ): VisualizationDataSource = VisualizationDataSource(db, teamsDatasource)
+    ): VisualizationDatasource = VisualizationDatasource(db, teamsDatasource)
 
     /**
      * Alternative provider for [FirebaseFirestore] using the [Firebase] accessor.

--- a/app/src/main/java/com/oracle/visualize/di/AppModule.kt
+++ b/app/src/main/java/com/oracle/visualize/di/AppModule.kt
@@ -5,6 +5,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 import com.google.firebase.auth.FirebaseAuth
 import com.oracle.visualize.data.datasources.AuthFirebaseSource
+import com.oracle.visualize.data.datasources.TeamDatasource
 import com.oracle.visualize.data.datasources.VisualizationDataSource
 import com.oracle.visualize.data.repositories.AuthRepositoryImpl
 import com.oracle.visualize.data.repositories.TeamRepositoryImpl
@@ -63,8 +64,9 @@ object FirebaseModule {
     @Provides
     @Singleton
     fun provideVisualizationDataSource(
-        db: FirebaseFirestore
-    ): VisualizationDataSource = VisualizationDataSource(db)
+        db: FirebaseFirestore,
+        teamsDatasource: TeamDatasource
+    ): VisualizationDataSource = VisualizationDataSource(db, teamsDatasource)
 
     /**
      * Alternative provider for [FirebaseFirestore] using the [Firebase] accessor.

--- a/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/ShareTeam.kt
@@ -8,5 +8,4 @@ data class ShareTeam(
     val name: String,
     val memberCount: Int,
     val members: List<ShareUser> = emptyList()
-
 )

--- a/app/src/main/java/com/oracle/visualize/domain/models/Team.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/Team.kt
@@ -5,7 +5,7 @@ package com.oracle.visualize.domain.models
  */
 data class Team (
     val id: String,
-    val memberIDs: List<String>,
+    val members: List<User> = emptyList(),
     val name: String,
     val ownerID: String
 )

--- a/app/src/main/java/com/oracle/visualize/domain/models/VisualizationCard.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/VisualizationCard.kt
@@ -11,6 +11,8 @@ data class VisualizationCard(
     val title: String,
     val author: String,
     val createdAt: Date,
-    val sharedWith: List<User>,
-    val configJSON: String
+    val configJSON: String,
+    val teamsSharedWith: List<Team>,
+    val usersSharedWith: List<User>,
+    val allUsersSharedWith: List<User>
 )

--- a/app/src/main/java/com/oracle/visualize/domain/repositories/UserRepository.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/repositories/UserRepository.kt
@@ -8,8 +8,6 @@ import com.oracle.visualize.domain.models.User
  * Interface defining the operations for user management.
  */
 interface UserRepository {
-    suspend fun getUserByUserID(userId: String): User?
-    suspend fun getTeamsIntegratedByUser(userId: String): List<Team>
     suspend fun getUserSuggestionsByEmail(email: String): List<ShareUser>
 
 }

--- a/app/src/main/java/com/oracle/visualize/domain/repositories/VisualizationRepository.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/repositories/VisualizationRepository.kt
@@ -16,5 +16,7 @@ interface VisualizationRepository {
         sharedWithTeams: List<String>
     )
     suspend fun getAllVisualizations(): List<Visualization>
-    suspend fun getAllVisualizationsByUserID(userID: String, filter: VisualizationFilter): List<VisualizationCard>
+    suspend fun getSharedVisualizations(userID: String): List<VisualizationCard>
+
+    suspend fun getPersonalVisualizations(userID: String): List<VisualizationCard>
 }

--- a/app/src/main/java/com/oracle/visualize/domain/usecases/GetAllUserVisualizationsUseCase.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/usecases/GetAllUserVisualizationsUseCase.kt
@@ -4,6 +4,8 @@ import com.oracle.visualize.domain.exceptions.AppError
 import com.oracle.visualize.domain.models.VisualizationCard
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
 import com.oracle.visualize.domain.repositories.VisualizationRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,16 +20,23 @@ class GetAllUserVisualizationsUseCase @Inject constructor(
 ){
     // Return type Result<List<VisualizationCard>>
     suspend operator fun invoke(userID: String, filter: VisualizationFilter): Result<List<VisualizationCard>> {
-
-        if (userID.isBlank()) {
-            return Result.failure(AppError.ValidationError("User ID does not exist."))
-        }
+        if (userID.isBlank()) return Result.failure(AppError.ValidationError("User ID empty"))
 
         return try {
-            val visualizations = visualizationRepository.getAllVisualizationsByUserID(userID, filter)
-            Result.success(visualizations)
-        } catch (ex: Exception) {
-            Result.failure(ex)
+            coroutineScope {
+                val cards = when (filter) {
+                    VisualizationFilter.ALL -> {
+                        val shared = async { visualizationRepository.getSharedVisualizations(userID) }
+                        val personal = async { visualizationRepository.getPersonalVisualizations(userID) }
+                        shared.await() + personal.await()
+                    }
+                    VisualizationFilter.SHARED -> visualizationRepository.getSharedVisualizations(userID)
+                    VisualizationFilter.PERSONAL -> visualizationRepository.getPersonalVisualizations(userID)
+                }
+                Result.success(cards)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/components/FeedCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/FeedCard.kt
@@ -143,7 +143,7 @@ fun FeedCard(item: VisualizationCard, onClick: () -> Unit = {}) {
                     .heightIn(min = 41.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                MemberAvatarStackFeed(item.sharedWith)
+                MemberAvatarStackFeed(item.allUsersSharedWith)
                 Spacer(modifier = Modifier.width(8.dp))
             }
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
@@ -83,7 +83,8 @@ fun FeedPage(
                             Spacer(modifier = Modifier.height(8.dp))
                         }
                         items(uiState.items) { item ->
-                            FeedCard(item,
+                            FeedCard(
+                                item,
                                 onClick = {
                                     onVisualizationClick(item.id)
                                 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
@@ -96,7 +96,7 @@ fun FullVisualizationPage(
                         FullVisualizationTopBar (
                             teamName = visualization.author,
                             visualizationTitle = visualization.title,
-                            members = visualization.sharedWith,
+                            members = visualization.allUsersSharedWith,
                             onBackClick = onBackClick
                         )
 

--- a/app/src/test/java/com/oracle/visualize/fixtures/VisualizationFixtures.kt
+++ b/app/src/test/java/com/oracle/visualize/fixtures/VisualizationFixtures.kt
@@ -12,7 +12,9 @@ object VisualizationFixtures {
         title = "Chart A",
         author = "John",
         createdAt = Date(),
-        sharedWith = emptyList(),
+        teamsSharedWith = emptyList(),
+        usersSharedWith = emptyList(),
+        allUsersSharedWith = emptyList(),
         configJSON = "{}"
     )
 

--- a/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
@@ -135,7 +135,7 @@ class GetAllUserVisualizationsUCTest {
         val exception = Exception("Firestore unavailable")
         coEvery {
             visualizationRepository.getSharedVisualizations(any())
-        } throws exception¥
+        } throws exception
 
         // when
         val result = getAllUserVisualizations(

--- a/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
@@ -52,21 +52,22 @@ class GetAllUserVisualizationsUCTest {
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is AppError.ValidationError)
         coVerify(exactly = 0) {
-            visualizationRepository.getAllVisualizationsByUserID(any(), any())
+            visualizationRepository.getSharedVisualizations(any())
+            visualizationRepository.getPersonalVisualizations(any())
         }
     }
 
     //Calls to the Repository
 
     @Test
-    fun validUserID_returnsResultSuccess_withVisualizationList() = runTest {
+    fun validUserID_withFilterAll_callsBothAndReturnsCombinedResultSuccess() = runTest {
         // given
         coEvery {
-            visualizationRepository.getAllVisualizationsByUserID(
-                VisualizationFixtures.VALID_USER_ID,
-                VisualizationFilter.ALL
-            )
+            visualizationRepository.getSharedVisualizations(VisualizationFixtures.VALID_USER_ID)
         } returns VisualizationFixtures.fakeVisualizations
+        coEvery {
+            visualizationRepository.getPersonalVisualizations(VisualizationFixtures.VALID_USER_ID)
+        } returns emptyList()
 
         // when
         val result = getAllUserVisualizations(
@@ -78,10 +79,8 @@ class GetAllUserVisualizationsUCTest {
         assertTrue(result.isSuccess)
         assertEquals(VisualizationFixtures.fakeVisualizations, result.getOrNull())
         coVerify(exactly = 1) {
-            visualizationRepository.getAllVisualizationsByUserID(
-                VisualizationFixtures.VALID_USER_ID,
-                VisualizationFilter.ALL
-            )
+            visualizationRepository.getSharedVisualizations(VisualizationFixtures.VALID_USER_ID)
+            visualizationRepository.getPersonalVisualizations(VisualizationFixtures.VALID_USER_ID)
         }
     }
 
@@ -89,10 +88,10 @@ class GetAllUserVisualizationsUCTest {
     fun validUserID_withNoVisualizations_returnsEmptyList() = runTest {
         // given
         coEvery {
-            visualizationRepository.getAllVisualizationsByUserID(
-                VisualizationFixtures.VALID_USER_ID,
-                VisualizationFilter.ALL
-            )
+            visualizationRepository.getSharedVisualizations(VisualizationFixtures.VALID_USER_ID)
+        } returns emptyList()
+        coEvery {
+            visualizationRepository.getPersonalVisualizations(VisualizationFixtures.VALID_USER_ID)
         } returns emptyList()
 
         // when
@@ -107,27 +106,26 @@ class GetAllUserVisualizationsUCTest {
     }
 
     @Test
-    fun filterIsForwardedToRepository() = runTest {
-        // given - verify the filter enum is forwarded, not hardcoded
+    fun filterPersonal_callsOnlyPersonalVisualizations() = runTest {
+        // given
         coEvery {
-            visualizationRepository.getAllVisualizationsByUserID(
-                VisualizationFixtures.VALID_USER_ID,
-                VisualizationFilter.PERSONAL
-            )
+            visualizationRepository.getPersonalVisualizations(VisualizationFixtures.VALID_USER_ID)
         } returns VisualizationFixtures.fakeVisualizations
 
         // when
-        getAllUserVisualizations(
+        val result = getAllUserVisualizations(
             VisualizationFixtures.VALID_USER_ID,
             VisualizationFilter.PERSONAL
         )
 
         // then
+        assertTrue(result.isSuccess)
+        assertEquals(VisualizationFixtures.fakeVisualizations, result.getOrNull())
         coVerify(exactly = 1) {
-            visualizationRepository.getAllVisualizationsByUserID(
-                VisualizationFixtures.VALID_USER_ID,
-                VisualizationFilter.PERSONAL
-            )
+            visualizationRepository.getPersonalVisualizations(VisualizationFixtures.VALID_USER_ID)
+        }
+        coVerify(exactly = 0) {
+            visualizationRepository.getSharedVisualizations(any())
         }
     }
 
@@ -136,19 +134,18 @@ class GetAllUserVisualizationsUCTest {
         // given
         val exception = Exception("Firestore unavailable")
         coEvery {
-            visualizationRepository.getAllVisualizationsByUserID(any(), any())
-        } throws exception
+            visualizationRepository.getSharedVisualizations(any())
+        } throws exception¥
 
         // when
         val result = getAllUserVisualizations(
             VisualizationFixtures.VALID_USER_ID,
-            VisualizationFilter.ALL
+            // Usamos SHARED para forzar que falle directamente con ese mock
+            VisualizationFilter.SHARED
         )
 
         // then
         assertTrue(result.isFailure)
         assertEquals(exception, result.exceptionOrNull())
     }
-
-
 }

--- a/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
+++ b/app/src/test/java/com/oracle/visualize/usecases/GetAllUserVisualizationsUCTest.kt
@@ -140,7 +140,7 @@ class GetAllUserVisualizationsUCTest {
         // when
         val result = getAllUserVisualizations(
             VisualizationFixtures.VALID_USER_ID,
-            // Usamos SHARED para forzar que falle directamente con ese mock
+            // We use SHARED to force it to fail immediately with that mock
             VisualizationFilter.SHARED
         )
 


### PR DESCRIPTION
📝 Summary
This PR addresses an issue where visualizations shared via teams were omitted from the user's feed. It also includes a significant architectural refactor to strictly enforce Clean Architecture principles by moving all data-filtering business logic into the Domain layer (Use Cases), alongside comprehensive error handling improvements.

🛠 Key Changes
Feed Fix: Visualizations are now properly served to the user if they inherit access through a team, rather than restricting the feed only to visualizations shared with them directly.

Share Indicator Update: The UI share indicator on the visualization cards has been updated. It now accurately calculates and displays all users who have access to the visualization (combining individual shares and team-based access).

Architecture Refactor: Encapsulated all business logic within the Use Case. Repositories have been simplified to act purely as data providers, while the Use Case now handles the responsibility of applying filters (e.g., hidden visualizations preferences).

Error Handling: Added custom AppError handling (such as ParsingError and NetworkError) to the newly implemented functions in the DataSources to ensure safer data parsing and network requests.