### PR TITLE
Optimizes Feed Loading

### DIFF
--- a/app/src/main/java/com/oracle/visualize/data/mapper/VisualizationMappers.kt
+++ b/app/src/main/java/com/oracle/visualize/data/mapper/VisualizationMappers.kt
@@ -53,6 +53,7 @@ fun VisualizationDTO.toVisualizationCard(
         id = this.id ?: "",
         title = this.title,
         author = authorName,
+        authorID = this.authorID,
         createdAt = this.createdAt.toDate(),
         configJSON = this.configJSON,
         teamsSharedWith = teamsSharedWith,

--- a/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
@@ -126,7 +126,7 @@ class VisualizationRepositoryImpl @Inject constructor(
         val allUsers = mutableListOf<UserDTO>()
         val chunkSize = 30
 
-        // chunked() es equivalente al stride de Swift para dividir el array
+        // ´chunked()´ is equivalent to Swift's ´stride´ for splitting the array 
         ids.chunked(chunkSize).forEach { chunk ->
             val chunkUsers = userDatasource.getUsersByIDs(chunk)
             allUsers.addAll(chunkUsers)

--- a/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/VisualizationRepositoryImpl.kt
@@ -3,14 +3,19 @@ package com.oracle.visualize.data.repositories
 import com.oracle.visualize.data.datasources.TeamDatasource
 import com.oracle.visualize.data.datasources.UserDatasource
 import com.oracle.visualize.data.datasources.VisualizationDatasource
+import com.oracle.visualize.data.datasources.dtos.TeamDTO
+import com.oracle.visualize.data.datasources.dtos.UserDTO
 import com.oracle.visualize.data.datasources.dtos.VisualizationDTO
 import com.oracle.visualize.data.mapper.toDomain
 import com.oracle.visualize.data.mapper.toVisualizationCard
 import com.oracle.visualize.domain.models.Visualization
 import com.oracle.visualize.domain.models.VisualizationCard
 import com.oracle.visualize.domain.repositories.VisualizationRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import java.util.Date
 import javax.inject.Inject
+import kotlin.collections.flatMap
 
 /**
  * Implementation of [VisualizationRepository] that manages visualization data.
@@ -51,43 +56,94 @@ class VisualizationRepositoryImpl @Inject constructor(
 
     override suspend fun getSharedVisualizations(userID: String): List<VisualizationCard> {
         val dtos = visualizationDataSource.getAllSharedVisualizations(userID)
-        return fetchDetailsAndMap(dtos)
+        return fetchDetailsAndMapBatch(dtos, userID)
     }
 
     override suspend fun getPersonalVisualizations(userID: String): List<VisualizationCard> {
         val dtos = visualizationDataSource.getPersonalVisualizations(userID)
-        return fetchDetailsAndMap(dtos)
+        return fetchDetailsAndMapBatch(dtos, userID)
     }
 
-    private suspend fun fetchDetailsAndMap(dtos: List<VisualizationDTO>): List<VisualizationCard> {
-        val cards = mutableListOf<VisualizationCard>()
-        for (dto in dtos) {
-            val authorDTO = userDatasource.getUserByID(dto.authorID)
-            val authorName = authorDTO.username
+    private suspend fun fetchDetailsAndMapBatch(
+        dtos: List<VisualizationDTO>,
+        userID: String
+    ): List<VisualizationCard> = coroutineScope {
+        if (dtos.isEmpty()) return@coroutineScope emptyList()
 
-            val usersDTOs = userDatasource.getUsersByIDs(dto.sharedWithUsers)
-            val usersSharedWith = usersDTOs.map { it.toDomain() }
+        val currentUser = userDatasource.getUserByID(userID)
+        val hiddenIDs = currentUser.hiddenVisualizations?.toSet() ?: emptySet()
 
-            val teamsDTOs = teamsDatasource.getTeamsByIDs(dto.sharedWithTeams)
+        val visibleDTOs = dtos.filter { dto ->
+            val id = dto.id ?: return@filter false
+            !hiddenIDs.contains(id)
+        }
 
-            val uniqueMemberIDs = teamsDTOs.flatMap { it.membersIDs }.toSet().toList()
-            val membersDTOs = userDatasource.getUsersByIDs(uniqueMemberIDs)
-            val allMembers = membersDTOs.map { it.toDomain() }
+        if (visibleDTOs.isEmpty()) return@coroutineScope emptyList()
 
-            val teamsSharedWith = teamsDTOs.map { teamDTO ->
-                val specificTeamMembers = allMembers.filter { member ->
-                    teamDTO.membersIDs.contains(member.id)
-                }
+        val authorIDs = visibleDTOs.map { it.authorID }.toSet()
+        val sharedUserIDs = visibleDTOs.flatMap { it.sharedWithUsers }.toSet()
+        val allUserIDsToFetch = (authorIDs + sharedUserIDs).toList()
+
+        val sharedTeamIDs = visibleDTOs.flatMap { it.sharedWithTeams }.toSet().toList()
+
+        val usersDeferred = async { fetchUsersInChunks(allUserIDsToFetch) }
+        val teamsDeferred = async { fetchTeamsInChunks(sharedTeamIDs) }
+
+        val usersDTOs = usersDeferred.await()
+        val teamsDTOs = teamsDeferred.await()
+
+        val usersDict = usersDTOs.associateBy { it.id }.toMutableMap()
+        val teamsDict = teamsDTOs.associateBy { it.id }
+
+        val teamMemberIDs = teamsDTOs.flatMap { it.membersIDs }.toSet()
+        val missingUserIDs = teamMemberIDs.filter { !usersDict.containsKey(it) }
+
+        if (missingUserIDs.isNotEmpty()) {
+            val missingUsers = fetchUsersInChunks(missingUserIDs)
+            usersDict.putAll(missingUsers.associateBy { it.id })
+        }
+
+        visibleDTOs.map { dto ->
+            val authorName = usersDict[dto.authorID]?.username ?: "Unknown"
+
+            val usersSharedWith = dto.sharedWithUsers.mapNotNull { usersDict[it]?.toDomain() }
+
+            val teamsSharedWith = dto.sharedWithTeams.mapNotNull { teamID ->
+                val teamDTO = teamsDict[teamID] ?: return@mapNotNull null
+                val specificTeamMembers = teamDTO.membersIDs.mapNotNull { usersDict[it]?.toDomain() }
                 teamDTO.toDomain(specificTeamMembers)
             }
 
-            val card = dto.toVisualizationCard(
+            dto.toVisualizationCard(
                 authorName = authorName,
                 teamsSharedWith = teamsSharedWith,
                 usersSharedWith = usersSharedWith
             )
-            cards.add(card)
         }
-        return cards
+    }
+
+    private suspend fun fetchUsersInChunks(ids: List<String>): List<UserDTO> {
+        val allUsers = mutableListOf<UserDTO>()
+        val chunkSize = 30
+
+        // chunked() es equivalente al stride de Swift para dividir el array
+        ids.chunked(chunkSize).forEach { chunk ->
+            val chunkUsers = userDatasource.getUsersByIDs(chunk)
+            allUsers.addAll(chunkUsers)
+        }
+
+        return allUsers
+    }
+
+    private suspend fun fetchTeamsInChunks(ids: List<String>): List<TeamDTO> {
+        val allTeams = mutableListOf<TeamDTO>()
+        val chunkSize = 30
+
+        ids.chunked(chunkSize).forEach { chunk ->
+            val chunkTeams = teamsDatasource.getTeamsByIDs(chunk)
+            allTeams.addAll(chunkTeams)
+        }
+
+        return allTeams
     }
 }

--- a/app/src/main/java/com/oracle/visualize/domain/models/VisualizationCard.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/VisualizationCard.kt
@@ -10,6 +10,7 @@ data class VisualizationCard(
     val id: String,
     val title: String,
     val author: String,
+    val authorID: String,
     val createdAt: Date,
     val configJSON: String,
     val teamsSharedWith: List<Team>,

--- a/app/src/main/java/com/oracle/visualize/domain/usecases/GetAllUserVisualizationsUseCase.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/usecases/GetAllUserVisualizationsUseCase.kt
@@ -19,20 +19,13 @@ class GetAllUserVisualizationsUseCase @Inject constructor(
     private val visualizationRepository: VisualizationRepository
 ){
     // Return type Result<List<VisualizationCard>>
-    suspend operator fun invoke(userID: String, filter: VisualizationFilter): Result<List<VisualizationCard>> {
+    suspend operator fun invoke(userID: String): Result<List<VisualizationCard>> {
         if (userID.isBlank()) return Result.failure(AppError.ValidationError("User ID empty"))
-
         return try {
             coroutineScope {
-                val cards = when (filter) {
-                    VisualizationFilter.ALL -> {
-                        val shared = async { visualizationRepository.getSharedVisualizations(userID) }
-                        val personal = async { visualizationRepository.getPersonalVisualizations(userID) }
-                        shared.await() + personal.await()
-                    }
-                    VisualizationFilter.SHARED -> visualizationRepository.getSharedVisualizations(userID)
-                    VisualizationFilter.PERSONAL -> visualizationRepository.getPersonalVisualizations(userID)
-                }
+                val shared = async { visualizationRepository.getSharedVisualizations(userID) }
+                val personal = async { visualizationRepository.getPersonalVisualizations(userID) }
+                val cards = shared.await() + personal.await()
                 Result.success(cards)
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -52,13 +53,15 @@ fun FeedPage(
             )
         }
     ) { paddingValues ->
-        Box(
+        PullToRefreshBox(
+            isRefreshing = uiState.isLoading && uiState.items.isNotEmpty(),
+            onRefresh = { feedViewModel.loadData(forceRefresh = true) },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
             when {
-                uiState.isLoading -> {
+                uiState.isLoading && uiState.items.isEmpty() -> {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
                 }
                 uiState.errorMessage != null -> {
@@ -67,12 +70,18 @@ fun FeedPage(
                         modifier = Modifier.align(Alignment.Center)
                     )
                 }
+                uiState.items.isEmpty() && !uiState.isLoading -> {
+                    Text(
+                        text = "No visualizations found.",
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
                 else -> {
                     LazyColumn(
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(horizontal = 16.dp, vertical = 0.dp)
+                            .padding(horizontal = 16.dp)
                     ) {
                         item {
                             Spacer(modifier = Modifier.height(22.dp))
@@ -82,12 +91,13 @@ fun FeedPage(
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                         }
-                        items(uiState.items) { item ->
+                        items(
+                            items = uiState.items,
+                            key = { it.id }
+                        ) { item ->
                             FeedCard(
-                                item,
-                                onClick = {
-                                    onVisualizationClick(item.id)
-                                }
+                                item = item,
+                                onClick = { onVisualizationClick(item.id) }
                             )
                         }
                         item {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -29,42 +29,40 @@ class FeedViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(FeedUIState())
     val uiState: StateFlow<FeedUIState> = _uiState.asStateFlow()
 
-    private var allItems: List<VisualizationCard> = emptyList()
+    private var allVisualizations: List<VisualizationCard> = emptyList()
+    // TODO: Get from Auth Repository
+    private val currentUserID: String = "e9Nk8XrxHJAtwN3Hf2FL"
 
     init {
-        fetchItems(VisualizationFilter.ALL)
+        loadData(forceRefresh = false)
     }
 
-    private fun fetchItems(filter: VisualizationFilter) {
-        viewModelScope.launch {
+    fun loadData(forceRefresh: Boolean = false) {
+        if (forceRefresh) {
+            allVisualizations = emptyList()
+        }
+
+        if (allVisualizations.isEmpty()) {
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        }
 
-            // TODO: Get from Auth Repository
-            val userID = "oEJtQz0gdbRpTZ8ETPCy"
-
-            getAllUserVisualizationsUseCase(userID, filter).fold(
-                onSuccess = { visualizations ->
-                    allItems = visualizations
-                    applySearch()
+        viewModelScope.launch {
+            getAllUserVisualizationsUseCase(currentUserID).fold(
+                onSuccess = { items ->
+                    allVisualizations = items
+                    applyLocalFilterAndSearch()
                 },
                 onFailure = { error ->
-                    allItems = emptyList()
-
+                    allVisualizations = emptyList()
                     val uiErrorMessage = when (error) {
                         is AppError.NetworkError -> "Connection error. Please check your internet."
                         is AppError.ParsingError -> "There was a problem reading some visualizations."
                         is AppError.NotFound -> "No visualizations found."
                         else -> "An unexpected error occurred. Please try again."
                     }
-
                     Log.e("FeedViewModel", "Error fetching visualizations: ${error.message}", error)
-
                     _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            items = emptyList(),
-                            errorMessage = uiErrorMessage
-                        )
+                        it.copy(isLoading = false, items = emptyList(), errorMessage = uiErrorMessage)
                     }
                 }
             )
@@ -72,24 +70,43 @@ class FeedViewModel @Inject constructor(
     }
 
     fun onFilterChange(filter: VisualizationFilter) {
-        _uiState.update { it.copy(selectedFilter = filter, searchText = "") }
-        fetchItems(filter)
-    }
+        if (_uiState.value.selectedFilter == filter) return
 
+        _uiState.update { it.copy(selectedFilter = filter) }
+
+        if (allVisualizations.isNotEmpty()) {
+            applyLocalFilterAndSearch()
+        } else {
+            loadData()
+        }
+    }
     fun onSearchTextChange(newText: String) {
         _uiState.update { it.copy(searchText = newText) }
-        applySearch()
+        applyLocalFilterAndSearch()
     }
 
-    private fun applySearch() {
-        val currentSearch = _uiState.value.searchText
-        val filteredItems = if (currentSearch.isBlank()) {
-            allItems
-        } else {
-            allItems.filter { item ->
-                item.title.contains(currentSearch, ignoreCase = true)
+    private fun applyLocalFilterAndSearch() {
+        val filter = _uiState.value.selectedFilter
+        val search = _uiState.value.searchText
+
+        var filteredItems = when (filter) {
+            VisualizationFilter.ALL -> allVisualizations
+            VisualizationFilter.PERSONAL -> allVisualizations.filter { it.authorID == currentUserID }
+            VisualizationFilter.SHARED -> allVisualizations.filter { it.authorID != currentUserID }
+        }
+
+        if (search.isNotBlank()) {
+            filteredItems = filteredItems.filter { item ->
+                item.title.contains(search, ignoreCase = true)
             }
         }
-        _uiState.update { it.copy(items = filteredItems, isLoading = false) }
+
+        _uiState.update {
+            it.copy(
+                items = filteredItems,
+                isLoading = false,
+                errorMessage = null
+            )
+        }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationViewModel.kt
@@ -25,6 +25,7 @@ class FullVisualizationViewModel @Inject constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(FullVisualizationUIState())
     val uiState: StateFlow<FullVisualizationUIState> = _uiState.asStateFlow()
+    private val currentUserID: String = "e9Nk8XrxHJAtwN3Hf2FL"
 
     fun loadVisualization(visualizationId: String) {
         viewModelScope.launch {
@@ -36,9 +37,7 @@ class FullVisualizationViewModel @Inject constructor(
             }
 
             //TODO: Get from Auth Repository
-            val userID = "oEJtQz0gdbRpTZ8ETPCy"
-
-            getAllUserVisualizationsUseCase(userID, VisualizationFilter.ALL).fold(
+            getAllUserVisualizationsUseCase(currentUserID).fold(
                 onSuccess = { visualizations ->
                     val visualization = visualizations.find { it.id == visualizationId }
 


### PR DESCRIPTION
### What this change does
* **Client-side filtering:** Modifies `FeedViewModel` to fetch the complete feed (`.all`) only once. Switching between the "All", "Personal", and "Shared" tabs now filters the data locally in memory instead of making new network requests.
* **N+1 Query Fix:** Refactors `VisualizationRepositoryImpl` to use batch fetching (`fetchUsersInChunks`). It now gathers all unique author and team IDs and fetches them in parallel, avoiding multiple individual document reads from Firestore.
* **Hidden Visualizations:** Intercepts and filters out the user's `hiddenVisualizations` at the repository layer before mapping the data.
* **UX Improvements:** Replaces the text loading screen with a Skeleton View (`LoadingListView`) to prevent layout shifts, and adds a pull-to-refresh functionality (`.refreshable`) to allow manual cache invalidation.
* **Maintenance:** Removes remaining development checkpoints and merges the latest changes from the `develop` branch.

### Why it was made
* The feed was taking too long to load due to redundant network calls every time a user changed the filter. Additionally, the mapping process was executing dozens of individual Firebase reads per visualization (N+1 problem).
* Filtering locally on the client provides an instantaneous UI response when switching tabs, drastically improving the user experience and reducing Firestore read costs.

### How it was tested
* Tested locally on the iOS simulator/device.
* Verified that toggling between feed filters (All, Personal, Shared) updates the list instantly without triggering new Firestore queries.
* Confirmed that performing a pull-to-refresh successfully clears the local `allVisualizations` array and fetches fresh data from the database.
* Ensured that items listed in the user's `hiddenVisualizations` array do not appear in the main feed.

### Risks, limitations, or follow-ups
* **Limitation:** The current client-side filtering approach relies on fetching all of the user's non-hidden visualizations upfront.
* **Follow-up:** If the application scales and users start having hundreds or thousands of visualizations in their feed, we will need to transition to server-side pagination (`limit` and `startAfter`) to prevent high memory consumption and slow initial load times. For the prototype this shouldn't be an issue.
* **Risk:** The 30-item limit for Firestore's `whereField(in:)` queries was mitigated using the `fetchUsersInChunks` helper function. Its performance should be monitored to ensure it remains efficient with larger datasets.