### PR TITLE
chore: .gitignrore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ local.properties
 *.txt
 *.log
 *.sh
+app/src/debug

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .idea/
 .gradle
 .kotlin
-/app/google-services.json
+app/google-services.json
 /local.properties
 /.idea/caches
 /.idea/libraries
@@ -16,3 +16,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+*.txt
+*.log
+*.sh

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,6 @@
 /build
-/google-services.json
+/debug
+google-services.json
+*.sh
+*.txt
+*.log


### PR DESCRIPTION
The file types `.sh`, `.txt`, and `.sh` were added to the ignore list, along with the `debug` folders and a clearer instruction to ignore the `google-services.json` file in the project. This is because these file types have been uploaded to the repository multiple times.