### PR TITLE
chore(security): disable FLAG_SECURE on debug builds

### DIFF
--- a/app/src/main/java/com/oracle/visualize/MainActivity.kt
+++ b/app/src/main/java/com/oracle/visualize/MainActivity.kt
@@ -24,8 +24,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Prevent screenshots and screen recording for security
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        // Apply window security measures only in production (Release) builds.
+        // Allows screenshots in debug builds to facilitate testing and QA reporting.
+        if (!BuildConfig.DEBUG){
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
 
         enableEdgeToEdge()
         setContent {


### PR DESCRIPTION
# PR: `chore(security): disable FLAG_SECURE on debug builds`

This PR disables `FLAG_SECURE` when debugging the app in this profile, so that screenshots can be taken.

# Note:
1. To test how the flag works—as it would in the production app—you must run the app in the "profileable" profile using `Profiler: Run ‘app’ as profileable (low overhead)` in Android Studio.
