### PR TITLE
Fix: Duplicate display IDs in FeedCard

### DIFF
--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -74,7 +74,7 @@ class FeedViewModel @Inject constructor(
 
             getAllUserVisualizationsUseCase(currentUserID).fold(
                 onSuccess = { items ->
-                    allVisualizations = items
+                    allVisualizations = items.distinctBy { it.id }
                     applyLocalFilterAndSearch()
                 },
                 onFailure = { error ->


### PR DESCRIPTION
# PR: `Fix: Duplicate display IDs in FeedCard`

The purpose of this PR is to prevent duplicate views from appearing in `FeedView.kt`, as the previous implementation caused crashes.

Only file modified:
`FeedViewModel.kt`