### PR TITLE
Fix comment loading times

### DIFF
--- a/app/src/main/java/com/oracle/visualize/data/datasources/CommentDatasource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/CommentDatasource.kt
@@ -27,17 +27,18 @@ class CommentDatasource @Inject constructor(
     suspend fun createComment(
         visualizationId: String,
         commentDTO: CommentDTO
-    ) {
+    ): String {
+        val docRef = commentsRef(visualizationId).document()
+
         val formattedComment = hashMapOf(
             "authorID" to commentDTO.authorID,
             "content" to commentDTO.content,
             "createdAt" to Timestamp.now(),
             "imageURL" to commentDTO.imageURL
         )
-        commentsRef(visualizationId)
-            .document()
-            .set(formattedComment)
-            .await()
+        docRef.set(formattedComment).await()
+
+        return docRef.id
     }
 
     suspend fun getComments(visualizationId: String): List<CommentDTO> {
@@ -84,7 +85,12 @@ class CommentDatasource @Inject constructor(
         visualizationId: String,
         commentId: String,
         threadDTO: ThreadDTO
-    ) {
+    ): String {
+        val docRef = threadsRef(
+            visualizationId = visualizationId,
+            commentId = commentId
+        ).document()
+
         val formattedThread = hashMapOf(
             "authorID" to threadDTO.authorID,
             "authorName" to threadDTO.authorName,
@@ -92,10 +98,9 @@ class CommentDatasource @Inject constructor(
             "content" to threadDTO.content,
             "createdAt" to Timestamp.now()
         )
-        threadsRef(visualizationId = visualizationId, commentId = commentId)
-            .document()
-            .set(formattedThread)
-            .await()
+        docRef.set(formattedThread).await()
+
+        return docRef.id
     }
 
 }

--- a/app/src/main/java/com/oracle/visualize/data/repositories/CommentRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/CommentRepositoryImpl.kt
@@ -18,15 +18,21 @@ class CommentRepositoryImpl @Inject constructor(
         authorID: String,
         content: String,
         imageURL: String?
-    ) {
-        commentDatasource.createComment(
-            visualizationId = visualizationId,
-            commentDTO = CommentDTO(
-                authorID = authorID,
-                content = content,
-                imageURL = imageURL
-            )
+    ): Comment {
+        val commentDTO = CommentDTO(
+            authorID = authorID,
+            content = content,
+            imageURL = imageURL
         )
+
+        val id = commentDatasource.createComment(
+            visualizationId = visualizationId,
+            commentDTO = commentDTO
+        )
+
+        return commentDTO
+            .copy(id = id)
+            .toDomain()
     }
 
     override suspend fun getComments(
@@ -56,16 +62,22 @@ class CommentRepositoryImpl @Inject constructor(
         authorName: String,
         authorAvatarURL: String?,
         content: String
-    ) {
-        commentDatasource.createThread(
+    ): Thread {
+        val threadDTO = ThreadDTO(
+            authorID = authorID,
+            authorName = authorName,
+            authorAvatarURL = authorAvatarURL,
+            content = content
+        )
+
+        val id = commentDatasource.createThread(
             visualizationId = visualizationId,
             commentId = commentId,
-            threadDTO = ThreadDTO(
-                authorID = authorID,
-                authorName = authorName,
-                authorAvatarURL = authorAvatarURL,
-                content = content
-            )
+            threadDTO = threadDTO
         )
+
+        return threadDTO
+            .copy(id = id)
+            .toDomain()
     }
 }

--- a/app/src/main/java/com/oracle/visualize/domain/repositories/CommentRepository.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/repositories/CommentRepository.kt
@@ -9,7 +9,7 @@ interface CommentRepository {
         authorID: String,
         content: String,
         imageURL: String?
-    )
+    ): Comment
 
     suspend fun getComments(
         visualizationId: String
@@ -27,6 +27,6 @@ interface CommentRepository {
         authorName: String,
         authorAvatarURL: String?,
         content: String
-    )
+    ): Thread
 }
 

--- a/app/src/main/java/com/oracle/visualize/domain/usecases/CreateCommentUseCase.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/usecases/CreateCommentUseCase.kt
@@ -1,6 +1,7 @@
 package com.oracle.visualize.domain.usecases
 
 import com.oracle.visualize.domain.exceptions.AppError
+import com.oracle.visualize.domain.models.Comment
 import com.oracle.visualize.domain.repositories.CommentRepository
 import javax.inject.Inject
 
@@ -19,7 +20,7 @@ class CreateCommentUseCase @Inject constructor(
         authorID: String,
         content: String,
         imageURL: String? = null
-    ): Result<Unit> {
+    ): Result<Comment> {
 
         if (content.isBlank()) {
             return Result.failure(AppError.InvalidComment())

--- a/app/src/main/java/com/oracle/visualize/domain/usecases/CreateThreadUseCase.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/usecases/CreateThreadUseCase.kt
@@ -1,6 +1,7 @@
 package com.oracle.visualize.domain.usecases
 
 import com.oracle.visualize.domain.exceptions.AppError
+import com.oracle.visualize.domain.models.Thread
 import com.oracle.visualize.domain.repositories.CommentRepository
 import jakarta.inject.Inject
 
@@ -22,7 +23,7 @@ class CreateThreadUseCase @Inject constructor(
         authorName: String,
         authorAvatarURL: String?,
         content: String
-    ): Result<Unit> {
+    ): Result<Thread> {
         if (content.isBlank()) {
             return Result.failure(AppError.InvalidComment())
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/ThreadsViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/ThreadsViewModel.kt
@@ -175,8 +175,25 @@ class ThreadsViewModel @Inject constructor(
                 content = content,
                 imageURL = null
             ).fold(
-                onSuccess = {
-                    loadThreads(visualizationId)
+                onSuccess = { newComment ->
+                    val currentUserData = getUserDisplayData(currentUserID)
+
+                    val newCommentUi = CommentUiModel(
+                        id = newComment.id,
+                        authorID = newComment.authorID,
+                        authorName = currentUserData.first,
+                        authorImageURL = currentUserData.second,
+                        content = newComment.content,
+                        imageURL = newComment.imageURL,
+                        createdAt = newComment.createdAt,
+                        threads = emptyList()
+                    )
+
+                    _uiState.update {
+                        it.copy(
+                            comments = it.comments + newCommentUi
+                        )
+                    }
                 },
                 onFailure = { error ->
 
@@ -204,14 +221,30 @@ class ThreadsViewModel @Inject constructor(
                 authorAvatarURL = currentUserImageUrl,
                 content = content
             ).fold(
-                onSuccess = {
-                    _uiState.update {
-                        it.copy(
+                onSuccess = { newThread ->
+                    val newThreadUi = ThreadUiModel(
+                        id = newThread.id,
+                        authorID = newThread.authorID,
+                        authorName = newThread.authorName,
+                        authorImageURL = newThread.authorAvatarURL,
+                        content = newThread.content,
+                        createdAt = newThread.createdAt
+                    )
+                    _uiState.update { state ->
+                        state.copy(
                             replyingToCommentId = null,
-                            replyingToAuthorName = null
+                            replyingToAuthorName = null,
+                            comments = state.comments.map { comment ->
+                                if (comment.id == commentId) {
+                                    comment.copy(
+                                        threads = comment.threads + newThreadUi
+                                    )
+                                } else {
+                                    comment
+                                }
+                            }
                         )
                     }
-                    loadThreads(visualizationId)
                 },
                 onFailure = { error ->
                     _uiState.update {


### PR DESCRIPTION
Optimization of the loading times when sending a comment/thread.

Changes to existing files:

- CommentDatasource.kt 
- CommentRepository.kt
- CommentRepositorylmpl.kt
- CreateCommentUseCase.kt
- CreateThreadUseCase.kt
- ThreadsViewModel.kt

Reformulation of creation process so that user only gets the new comment instead of all comments over again