### PR TITLE
fix: duplicate display IDs in FeedCard - second part

### DIFF
--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -79,7 +79,7 @@ class FeedViewModel @Inject constructor(
             observeUserFeedUseCase(currentUserID, forceRefresh).collect { result ->
                 result.fold(
                     onSuccess = { items ->
-                        allFeedItems = items
+                        allFeedItems = items.distinctBy { it.card.id }
                         applyLocalFilterAndSearch()
                     },
                     onFailure = { error ->


### PR DESCRIPTION
# PR: `fix: duplicate display IDs in FeedCard - second part`

The purpose of this PR is to prevent duplicate views from appearing in `FeedView.kt`, as the previous implementation caused crashes.

Only file modified:
`FeedViewModel.kt`