### PR TITLE
Feature. Chart color palette

### DIFF
--- a/app/src/main/java/com/oracle/visualize/data/datasources/UserDatasource.kt
+++ b/app/src/main/java/com/oracle/visualize/data/datasources/UserDatasource.kt
@@ -150,4 +150,19 @@ class UserDatasource @Inject constructor(
         }
     }
 
+    /**
+     * Gets the chart color theme selected by the user.
+     *
+     * @param userID The unique ID of the user.
+     * @return The chart theme's name.
+     * @throws AppError.NotFound If the user doesn't exist.
+     * @throws AppError.NetworkError If a network error occurs.
+     */
+    suspend fun getChartTheme(userID: String): String {
+        val user = firestore.collection("users").document(userID).get().await()
+
+        if (!user.exists()) throw AppError.NotFound("User with ID $userID does not exist in the database.")
+
+        return user.get("chartTheme").toString()
+    }
 }

--- a/app/src/main/java/com/oracle/visualize/data/repositories/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/UserRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.oracle.visualize.domain.exceptions.AppError
 import com.oracle.visualize.domain.models.ShareUser
 import com.oracle.visualize.domain.models.User
 import com.oracle.visualize.domain.repositories.UserRepository
+import com.oracle.visualize.ui.theme.ChartPalette
 import javax.inject.Inject
 
 /**
@@ -64,5 +65,22 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun updatePfp(userId: String, uri: String): Unit {
         return userDatasource.updatePfp(userId, uri)
+    }
+
+    override suspend fun getChartTheme(userID: String): ChartPalette {
+        return try {
+            val color = userDatasource.getChartTheme(userID)
+            when (color) {
+                "THEME1" -> ChartPalette.THEME1
+                "THEME2" -> ChartPalette.THEME2
+                "THEME3" -> ChartPalette.THEME3
+                "THEME4" -> ChartPalette.THEME4
+                else -> ChartPalette.THEME1
+            }
+        } catch (e: AppError.NotFound) {
+            throw AppError.NotFound("User not found: ${e.message}")
+        } catch (e: AppError.NetworkError) {
+            throw AppError.NetworkError("Failed to get the chart theme: ${e.message}")
+        }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/domain/repositories/UserRepository.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/repositories/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.oracle.visualize.domain.repositories
 import com.oracle.visualize.domain.models.ShareUser
 import com.oracle.visualize.domain.models.User
+import com.oracle.visualize.ui.theme.ChartPalette
 
 interface UserRepository {
     suspend fun getUsersByIDs(userIDs: List<String>): List<ShareUser>
@@ -17,4 +18,5 @@ interface UserRepository {
 
     suspend fun updatePfp(userID: String, uri: String): Unit
 
+    suspend fun getChartTheme(userID: String): ChartPalette
 }

--- a/app/src/main/java/com/oracle/visualize/domain/usecases/chart/GetUserChartThemeUseCase.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/usecases/chart/GetUserChartThemeUseCase.kt
@@ -1,0 +1,24 @@
+package com.oracle.visualize.domain.usecases.chart
+
+import com.oracle.visualize.domain.exceptions.AppError
+import com.oracle.visualize.domain.repositories.UserRepository
+import com.oracle.visualize.ui.theme.ChartPalette
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+/**
+ * Use case to get a user's Chart Theme value from the database.
+ *
+ * @returns Result<ChartPalette> A Result that only indicates if the operation succeeded or failed.
+ * @property userRepository The repository to change the selected chart theme.
+ */
+@Singleton
+class GetUserChartThemeUseCase @Inject constructor(
+    private val userRepository: UserRepository
+){
+    suspend operator fun invoke(userID: String): Result<ChartPalette> {
+        if (userID.isBlank()) return Result.failure(AppError.GeneralValidationError("User ID empty"))
+        return runCatching { userRepository.getChartTheme(userID) }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentFullScreen.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentFullScreen.kt
@@ -57,6 +57,7 @@ import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
 fun ChartRenderFullScreen(
     modifier: Modifier = Modifier,
     chart: Chart<*>,
+    chartColorTheme: ChartPalette = ChartPalette.THEME1,
     showAxisLabels: Boolean = true
 ) {
     val localConfig = LocalConfiguration.current
@@ -165,7 +166,7 @@ fun ChartRenderFullScreen(
                 Box(modifier = modifier.fillMaxSize()) {
                     Box(modifier = modifier.background(color = MaterialTheme.colorScheme.onPrimary)
                         .padding(horizontal = 10.dp).fillMaxSize()) {
-                        ChartRenderGeneral(modifier, chart, showAxisLabels)
+                        ChartRenderGeneral(modifier, chart, showAxisLabels = showAxisLabels)
                     }
                 }
             }

--- a/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentGeneral.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentGeneral.kt
@@ -46,6 +46,7 @@ import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
 fun ChartRenderGeneral(
     modifier: Modifier = Modifier,
     chart: Chart<*>,
+    chartColorTheme: ChartPalette = ChartPalette.THEME1,
     showAxisLabels: Boolean = true,
     enableTooltips: Boolean = true,
     enableZoomAndPan: Boolean = true,
@@ -72,15 +73,17 @@ fun ChartRenderGeneral(
 
                 Box(modifier = boxModifier) {
                     RenderVerticalBarChart(
-                        modifier = chartModifier, chart = chart, showAxisLabels = showAxisLabels, enableTooltips = enableTooltips,
-                        enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
+                        modifier = chartModifier, chart = chart, showAxisLabels = showAxisLabels, chartColorTheme = chartColorTheme,
+                        enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
                     )
                 }
             }
 
             is HorizontalBarChart -> {
-                RenderHorizontalBarChart(chart = chart, showAxisLabels = showAxisLabels, enableTooltips = enableTooltips,
-                    enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels)
+                RenderHorizontalBarChart(
+                    chart = chart, showAxisLabels = showAxisLabels, chartColorTheme = chartColorTheme,
+                    enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
+                )
             }
 
             is StackedBarChart -> {
@@ -92,29 +95,30 @@ fun ChartRenderGeneral(
 
                 Box(modifier = boxModifier) {
                     RenderStackedBarChart(
-                        modifier = chartModifier, chart = chart, showAxisLabels = showAxisLabels,
-                        enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan,
-                        feedCardLabels = feedCardLabels
+                        modifier = chartModifier, chart = chart, showAxisLabels = showAxisLabels, chartColorTheme = chartColorTheme,
+                        enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
                     )
                 }
             }
 
             is LineChart -> RenderLineChart(
-                chart = chart, showAxisLabels = showAxisLabels, enableTooltips = enableTooltips,
-                enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
+                chart = chart, showAxisLabels = showAxisLabels, chartColorTheme = chartColorTheme,
+                enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
             )
 
             is ScatterChart -> RenderScatterChart(
-                chart = chart, showAxisLabels = showAxisLabels, enableTooltips = enableTooltips,
-                enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
+                chart = chart, showAxisLabels = showAxisLabels, chartColorTheme = chartColorTheme,
+                enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan, feedCardLabels = feedCardLabels
             )
 
-            is PieChartModel -> RenderPieChart(chart = chart, enableTooltips = enableTooltips)
+            is PieChartModel -> RenderPieChart(chart = chart, chartColorTheme = chartColorTheme, enableTooltips = enableTooltips)
 
-            is DonutChart -> RenderDonutChart(chart = chart, enableTooltips = enableTooltips)
+            is DonutChart -> RenderDonutChart(chart = chart, chartColorTheme = chartColorTheme, enableTooltips = enableTooltips)
 
-            is AreaChart -> RenderAreaChart(chart = chart, showAxisLabels = showAxisLabels,
-                enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan)
+            is AreaChart -> RenderAreaChart(
+                chart = chart, showAxisLabels = showAxisLabels, chartColorTheme = chartColorTheme,
+                enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan
+            )
         }
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/components/FeedCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/FeedCard.kt
@@ -47,6 +47,7 @@ import com.oracle.visualize.domain.models.VisualizationCard
 import com.oracle.visualize.presentation.screens.feedScreen.components.FeedCardMenu
 import com.oracle.visualize.presentation.screens.feedScreen.components.MemberAvatarStackFeed
 import com.oracle.visualize.presentation.screens.feedScreen.components.skeletonEffect
+import com.oracle.visualize.ui.theme.ChartPalette
 import java.util.Date
 import java.util.concurrent.TimeUnit
 
@@ -72,6 +73,7 @@ fun FeedCard(
     currentUserID: String = "",
     onClick: () -> Unit = {},
     chart: Chart<*>?,
+    chartColorTheme: ChartPalette = ChartPalette.THEME1,
     isChartLoading: Boolean,
     onLoadChartRequest: () -> Unit,
     isDeletable: Boolean = false,
@@ -181,7 +183,8 @@ fun FeedCard(
                             showAxisLabels   = false,
                             enableTooltips   = false,
                             enableZoomAndPan = false,
-                            feedCardLabels   = true
+                            feedCardLabels   = true,
+                            chartColorTheme = chartColorTheme
                         )
                     } else {
                         Text(

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/AreaChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/AreaChartComponent.kt
@@ -60,7 +60,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalKoalaPlotApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun RenderAreaChart(
-    modifier: Modifier = Modifier, chart: AreaChart, showAxisLabels: Boolean,
+    modifier: Modifier = Modifier, chart: AreaChart, chartColorTheme: ChartPalette, showAxisLabels: Boolean,
     enableTooltips: Boolean, enableZoomAndPan: Boolean
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -71,7 +71,7 @@ fun RenderAreaChart(
     val minX = remember(sortedKeys) { sortedKeys.firstOrNull() ?: 0f }
     val maxX = remember(sortedKeys) { sortedKeys.lastOrNull() ?: 0f }
     val maxY = remember(data) { data.values.maxOfOrNull { it.sum() } ?: 0f }
-    val seriesColors = remember(seriesNames) { generateChartColors(seriesNames.size, ChartPalette.THEME1) }
+    val seriesColors = remember(seriesNames) { generateChartColors(seriesNames.size, chartColorTheme) }
 
     Box(modifier = modifier) {
         KoalaPlotTheme(axis = KoalaPlotTheme.axis.copy(color = Color.Gray, minorGridlineStyle = null)) {

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/DonutChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/DonutChartComponent.kt
@@ -33,13 +33,13 @@ import kotlin.math.roundToInt
  */
 @OptIn(ExperimentalKoalaPlotApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun RenderDonutChart(modifier: Modifier = Modifier, chart: DonutChart, enableTooltips: Boolean) {
+fun RenderDonutChart(modifier: Modifier = Modifier, chart: DonutChart, chartColorTheme: ChartPalette, enableTooltips: Boolean) {
     val coroutineScope = rememberCoroutineScope()
     val categories = chart.fieldNames
     val values = chart.data
     val valuesTotal = values.sum()
     val percentageValues = values.map { value -> (value/valuesTotal) * 100 }
-    val colors = generateChartColors(categories.size, ChartPalette.THEME1)
+    val colors = generateChartColors(categories.size, chartColorTheme)
 
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         PieChart(

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/HorizontalBarChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/HorizontalBarChartComponent.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RenderHorizontalBarChart(
-    modifier: Modifier = Modifier, chart: HorizontalBarChart, showAxisLabels: Boolean,
+    modifier: Modifier = Modifier, chart: HorizontalBarChart, chartColorTheme: ChartPalette, showAxisLabels: Boolean,
     enableTooltips: Boolean, enableZoomAndPan: Boolean, feedCardLabels: Boolean
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -67,7 +67,7 @@ fun RenderHorizontalBarChart(
     val values = remember(data) { data.values.toList() }
     val maxValue = remember(values) { values.maxOrNull() ?: 0f }
     val barColors = remember(categories) {
-        generateChartColors(categories.size, ChartPalette.THEME1)
+        generateChartColors(categories.size, chartColorTheme)
     }
 
     Box(modifier = Modifier) {

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/LineChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/LineChartComponent.kt
@@ -67,15 +67,15 @@ import kotlin.collections.component2
 @OptIn(ExperimentalKoalaPlotApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun RenderLineChart(
-    modifier: Modifier = Modifier, chart: LineChart, showAxisLabels: Boolean,
+    modifier: Modifier = Modifier, chart: LineChart, chartColorTheme: ChartPalette, showAxisLabels: Boolean,
     enableTooltips: Boolean, enableZoomAndPan: Boolean, feedCardLabels: Boolean
 ) {
     val coroutineScope = rememberCoroutineScope()
     val processedData = remember (chart.data) {
         listOf(DefaultPoint(0f, 0f)) + chart.data.map { (x, y) -> DefaultPoint(x, y) }
     }
-    val lineColor = generateChartColors(1, ChartPalette.THEME1).firstOrNull() ?: Color.Blue
-    val dotColors = generateChartColors(2, ChartPalette.THEME1)
+    val lineColor = generateChartColors(1, chartColorTheme).firstOrNull() ?: Color.Blue
+    val dotColors = generateChartColors(2, chartColorTheme)
 
     var xMetric = stringResource(R.string.line_scatter_x_metric)
     var yMetric = stringResource(R.string.line_scatter_y_metric)

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/PieChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/PieChartComponent.kt
@@ -27,13 +27,13 @@ import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
  */
 @OptIn(ExperimentalKoalaPlotApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun RenderPieChart(modifier: Modifier = Modifier, chart: PieChartModel, enableTooltips: Boolean) {
+fun RenderPieChart(modifier: Modifier = Modifier, chart: PieChartModel, chartColorTheme: ChartPalette, enableTooltips: Boolean) {
     val coroutineScope = rememberCoroutineScope()
     val categories = chart.fieldNames
     val values = chart.data
     val valuesTotal = values.sum()
     val percentageValues = values.map { value -> (value/valuesTotal) * 100 }
-    val colors = generateChartColors(categories.size, ChartPalette.THEME1)
+    val colors = generateChartColors(categories.size, chartColorTheme)
 
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         PieChart(

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/ScatterChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/ScatterChartComponent.kt
@@ -66,7 +66,7 @@ import kotlin.collections.component2
 @OptIn(ExperimentalKoalaPlotApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun RenderScatterChart(
-    modifier: Modifier = Modifier, chart: ScatterChart, showAxisLabels: Boolean,
+    modifier: Modifier = Modifier, chart: ScatterChart, chartColorTheme: ChartPalette, showAxisLabels: Boolean,
     enableTooltips: Boolean, enableZoomAndPan: Boolean, feedCardLabels: Boolean
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -74,7 +74,7 @@ fun RenderScatterChart(
         listOf(DefaultPoint(0f, 0f)) + chart.data.map { (x, y) -> DefaultPoint(x, y) }
     }
 
-    val dotColors = generateChartColors(2, ChartPalette.THEME1)
+    val dotColors = generateChartColors(2, chartColorTheme)
 
     var xMetric = stringResource(R.string.line_scatter_x_metric)
     var yMetric = stringResource(R.string.line_scatter_y_metric)

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/StackedBarChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/StackedBarChartComponent.kt
@@ -59,7 +59,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RenderStackedBarChart(
-    modifier: Modifier = Modifier, chart: StackedBarChart, showAxisLabels: Boolean,
+    modifier: Modifier = Modifier, chart: StackedBarChart, chartColorTheme: ChartPalette, showAxisLabels: Boolean,
     enableTooltips: Boolean, enableZoomAndPan: Boolean, feedCardLabels: Boolean
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -76,7 +76,7 @@ fun RenderStackedBarChart(
     }
 
     val seriesColors = remember(seriesNames.size) {
-        generateChartColors(seriesNames.size, ChartPalette.THEME1)
+        generateChartColors(seriesNames.size, chartColorTheme)
     }
 
     val maxY = remember(chart.data.values) { chart.data.values.maxOfOrNull { it.sum() } ?: 0f }

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/VerticalBarChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/VerticalBarChartComponent.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RenderVerticalBarChart(
-    chart: VerticalBarChart, modifier: Modifier = Modifier, showAxisLabels: Boolean,
+    modifier: Modifier = Modifier, chart: VerticalBarChart, chartColorTheme: ChartPalette, showAxisLabels: Boolean,
     enableTooltips: Boolean, enableZoomAndPan: Boolean, feedCardLabels: Boolean
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -67,7 +67,7 @@ fun RenderVerticalBarChart(
     val values = remember(data) { data.values.toList() }
     val maxValue = remember(values) { values.maxOrNull() ?: 0f }
     val barColors = remember(categories) {
-        generateChartColors(categories.size, ChartPalette.THEME1)
+        generateChartColors(categories.size, chartColorTheme)
     }
 
     Box(modifier = modifier) {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedUIState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedUIState.kt
@@ -2,6 +2,7 @@ package com.oracle.visualize.presentation.screens.feedScreen
 
 import com.oracle.visualize.domain.models.FeedItem
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
+import com.oracle.visualize.ui.theme.ChartPalette
 
 sealed interface FeedUiState {
 
@@ -20,6 +21,7 @@ sealed interface FeedUiState {
         val deleteDialogForId: String? = null,
         val hideDialogForId: String? = null,
         val isDeletableMap: Map<String, Boolean> = emptyMap(),
-        val pendingShareId: String? = null
+        val pendingShareId: String? = null,
+        val chartColorTheme: ChartPalette
     ) : FeedUiState
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedUIState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedUIState.kt
@@ -22,6 +22,6 @@ sealed interface FeedUiState {
         val hideDialogForId: String? = null,
         val isDeletableMap: Map<String, Boolean> = emptyMap(),
         val pendingShareId: String? = null,
-        val chartColorTheme: ChartPalette
+        val chartColorTheme: ChartPalette = ChartPalette.THEME1
     ) : FeedUiState
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
@@ -142,6 +142,7 @@ fun FeedPage(
                                 FeedCard(
                                     item                = feedItem.card,
                                     chart               = feedItem.chart,
+                                    chartColorTheme     = state.chartColorTheme,
                                     currentUserID       = state.currentUserID,
                                     isChartLoading      = feedItem.isChartLoading,
                                     onLoadChartRequest  = { feedViewModel.loadChartForCard(feedItem.card) },

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -9,10 +9,12 @@ import com.oracle.visualize.domain.models.FeedItem
 import com.oracle.visualize.domain.models.VisualizationCard
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
 import com.oracle.visualize.domain.repositories.AuthRepository
-import com.oracle.visualize.domain.usecases.DeleteVisualizationForEveryoneUseCase
-import com.oracle.visualize.domain.usecases.HideVisualizationForMeUseCase
 import com.oracle.visualize.domain.usecases.ObserveUserFeedUseCase
+import com.oracle.visualize.domain.usecases.chart.GetUserChartThemeUseCase
 import com.oracle.visualize.domain.usecases.chart.ParseSingleChartUseCase
+import com.oracle.visualize.domain.usecases.visualization.DeleteVisualizationForEveryoneUseCase
+import com.oracle.visualize.domain.usecases.visualization.HideVisualizationForMeUseCase
+import com.oracle.visualize.ui.theme.ChartPalette
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,6 +31,7 @@ class FeedViewModel @Inject constructor(
     private val parseSingleChartUseCase: ParseSingleChartUseCase,
     private val deleteVisualizationForEveryoneUseCase: DeleteVisualizationForEveryoneUseCase,
     private val hideVisualizationForMeUseCase: HideVisualizationForMeUseCase,
+    private val getUserChartThemeUseCase: GetUserChartThemeUseCase,
     private val feedCacheManager: FeedCacheManager
 ) : ViewModel() {
 
@@ -38,6 +41,8 @@ class FeedViewModel @Inject constructor(
     private var allFeedItems: List<FeedItem> = emptyList()
     private var currentUserID: String = ""
     private var feedJob: Job? = null
+
+    private var userChartTheme: ChartPalette? = null
 
     init {
         try {
@@ -84,6 +89,9 @@ class FeedViewModel @Inject constructor(
 
         feedJob?.cancel()
         feedJob = viewModelScope.launch {
+            val palette = getUserChartThemeUseCase(currentUserID)
+            userChartTheme = palette.getOrDefault(ChartPalette.THEME1)
+
             observeUserFeedUseCase(currentUserID, forceRefresh = true).collect { result ->
                 result.fold(
                     onSuccess = { items ->
@@ -224,7 +232,8 @@ class FeedViewModel @Inject constructor(
                 selectedFilter = filter,
                 isRefreshing   = false,
                 isSearching    = isSearching,
-                isDeletableMap = isDeletableMap
+                isDeletableMap = isDeletableMap,
+                chartColorTheme = userChartTheme!!,
             )
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationUIState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationUIState.kt
@@ -2,10 +2,12 @@ package com.oracle.visualize.presentation.screens.fullVisualizationScreen
 
 import com.oracle.visualize.domain.models.Chart
 import com.oracle.visualize.domain.models.VisualizationFullScreen
+import com.oracle.visualize.ui.theme.ChartPalette
 
 data class FullVisualizationUIState(
     val isLoading: Boolean = false,
     val visualization: VisualizationFullScreen? = null,
     val chart: Chart<*>? = null,
+    val chartColorTheme: ChartPalette,
     val errorMessage: Int? = null
 )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.viewModelScope
 import com.oracle.visualize.R
 import com.oracle.visualize.domain.exceptions.AppError
 import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.usecases.chart.GetUserChartThemeUseCase
 import com.oracle.visualize.domain.usecases.visualization.GetIndividualVisualizationUseCase
 import com.oracle.visualize.domain.usecases.chart.ParseFullScreenChartUseCase
+import com.oracle.visualize.ui.theme.ChartPalette
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +28,7 @@ import javax.inject.Inject
 @HiltViewModel
 class FullVisualizationViewModel @Inject constructor(
     private val getIndividualVisualizationUseCase: GetIndividualVisualizationUseCase,
+    private val getUserChartThemeUseCase: GetUserChartThemeUseCase,
     private val parseFullScreenChartUseCase: ParseFullScreenChartUseCase,
     private val authRepository: AuthRepository
 ) : ViewModel() {
@@ -37,6 +40,7 @@ class FullVisualizationViewModel @Inject constructor(
     case it becomes relevant for a future feature.
     */
     private var currentUserID: String = ""
+    private var userChartTheme: ChartPalette? = null
 
     init {
         currentUserID = authRepository.getCurrentUserID()
@@ -50,6 +54,9 @@ class FullVisualizationViewModel @Inject constructor(
                     errorMessage = null
                 )
             }
+
+            val chartColorThemeResult = getUserChartThemeUseCase(currentUserID)
+            userChartTheme = chartColorThemeResult.getOrDefault(ChartPalette.THEME1)
 
             getIndividualVisualizationUseCase(visualizationId).fold(
                 onSuccess = { visualization ->

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/profileScreen/components/ChartThemeSelector.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/profileScreen/components/ChartThemeSelector.kt
@@ -1,34 +1,56 @@
 package com.oracle.visualize.presentation.screens.profileScreen.components
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.oracle.visualize.R
 import com.oracle.visualize.ui.theme.ChartPalette
 import androidx.compose.ui.res.stringResource
+
+private var toast: Toast? = null
 
 @Composable
 fun ChartThemePicker(
     selectedPalette: String,
     onPaletteChange: (String) -> Unit
 ) {
+    val context = LocalContext.current
+
+    // Theme names
+    val changedThemeText = stringResource(R.string.chart_changed_to_theme)
+    val lagoon = stringResource(R.string.chart_theme_lagoon)
+    val sunset = stringResource(R.string.chart_theme_sunset)
+    val harvest = stringResource(R.string.chart_theme_harvest)
+    val petal = stringResource(R.string.chart_theme_petal)
+
     SettingsCard(title = stringResource(R.string.chart_theme_title), titleDrawableImage = R.drawable.baseline_color_lens_24) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Row(horizontalArrangement = Arrangement.spacedBy(32.dp)) {
                 ThemeItem(
                     palette = ChartPalette.THEME1,
                     isSelected = selectedPalette == ChartPalette.THEME1.name,
-                    onClick = { onPaletteChange(ChartPalette.THEME1.name) },
+                    onClick = {
+                        toast?.cancel()
+                        onPaletteChange(ChartPalette.THEME1.name)
+                        toast = Toast.makeText(context, "$changedThemeText $lagoon", Toast.LENGTH_SHORT)
+                        toast?.show()
+                    },
                     modifier = Modifier.weight(1f)
                 )
                 ThemeItem(
                     palette = ChartPalette.THEME2,
                     isSelected = selectedPalette == ChartPalette.THEME2.name,
-                    onClick = { onPaletteChange(ChartPalette.THEME2.name) },
+                    onClick = {
+                        toast?.cancel()
+                        onPaletteChange(ChartPalette.THEME2.name)
+                        toast = Toast.makeText(context, "$changedThemeText $sunset", Toast.LENGTH_SHORT)
+                        toast?.show()
+                    },
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -36,13 +58,23 @@ fun ChartThemePicker(
                 ThemeItem(
                     palette = ChartPalette.THEME3,
                     isSelected = selectedPalette == ChartPalette.THEME3.name,
-                    onClick = { onPaletteChange(ChartPalette.THEME3.name) },
+                    onClick = {
+                        toast?.cancel()
+                        onPaletteChange(ChartPalette.THEME3.name)
+                        toast = Toast.makeText(context, "$changedThemeText $harvest", Toast.LENGTH_SHORT)
+                        toast?.show()
+                    },
                     modifier = Modifier.weight(1f)
                 )
                 ThemeItem(
                     palette = ChartPalette.THEME4,
                     isSelected = selectedPalette == ChartPalette.THEME4.name,
-                    onClick = { onPaletteChange(ChartPalette.THEME4.name) },
+                    onClick = {
+                        toast?.cancel()
+                        onPaletteChange(ChartPalette.THEME4.name)
+                        toast = Toast.makeText(context, "$changedThemeText $petal", Toast.LENGTH_SHORT)
+                        toast?.show()
+                    },
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/SelectChartUIState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/SelectChartUIState.kt
@@ -1,5 +1,6 @@
 package com.oracle.visualize.presentation.screens.selectChartScreen
 import com.oracle.visualize.domain.models.Chart
+import com.oracle.visualize.ui.theme.ChartPalette
 import java.util.UUID
 /**
  * Represents the UI state for the Chart Selection screen.
@@ -23,6 +24,7 @@ data class ChartSelection(
     val id: String = UUID.randomUUID().toString(),
     val chartIndex: Int,
     val chart: Chart<*>,
+    val chartColorTheme: ChartPalette = ChartPalette.THEME1,
     val customTitle: String,
     val isSelected: Boolean = false
 )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/SelectChartView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/SelectChartView.kt
@@ -309,6 +309,7 @@ fun ChartSelectionPage(
                             Box(modifier = Modifier.padding(horizontal = 16.dp)) {
                                 ChartCard(
                                     chart = selection.chart,
+                                    chartColorTheme = selection.chartColorTheme,
                                     title = selection.customTitle,
                                     isSelected = selection.isSelected,
                                     onSelect = { viewModel.toggleSelection(selection.id) },

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/SelectChartViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/SelectChartViewModel.kt
@@ -23,20 +23,27 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.oracle.visualize.data.datasources.dtos.ChartResponseDTO
+import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.usecases.chart.GetUserChartThemeUseCase
 import com.oracle.visualize.domain.usecases.visualization.PublishVisualizationsInBulkUseCase
+import com.oracle.visualize.ui.theme.ChartPalette
 
 @HiltViewModel
 class SelectChartViewModel @Inject constructor(
     private val repository: AnalyzeRepository,
-    private val authRepository: com.oracle.visualize.domain.repositories.AuthRepository,
+    private val authRepository: AuthRepository,
+    private val getUserChartThemeUseCase: GetUserChartThemeUseCase,
     private val publishVisualizationsInBulkUseCase: PublishVisualizationsInBulkUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel(){
     val taskId: String = savedStateHandle.toRoute<NavRoutes.ChartSelection>().taskId
     private val _uiState = MutableStateFlow<ChartSelectionUiState>(ChartSelectionUiState.Loading)
     val uiState: StateFlow<ChartSelectionUiState> = _uiState.asStateFlow()
+    private var currentUserID: String = ""
+    private var userChartTheme: ChartPalette = ChartPalette.THEME1
 
     init {
+        currentUserID = authRepository.getCurrentUserID() ?: ""
         fetchOverview()
     }
 
@@ -47,6 +54,11 @@ class SelectChartViewModel @Inject constructor(
             val chartSelections = mutableListOf<ChartSelection>()
             var lastErrorMessageId: Int? = null
 
+            userChartTheme = when (val chartColorThemeResult = getUserChartThemeUseCase(currentUserID)){
+                is AppResult.Success -> chartColorThemeResult.data
+                is AppResult.Error -> userChartTheme
+            }
+
             for (chartIndex in 0..4) {
                 when (val result = repository.previewedResults(taskId, chartIndex, true)) {
                     is AppResult.Success -> {
@@ -55,6 +67,7 @@ class SelectChartViewModel @Inject constructor(
                                 ChartSelection(
                                     chartIndex = chartIndex,
                                     chart = chart,
+                                    chartColorTheme = userChartTheme,
                                     customTitle = chart.chartTitle,
                                     isSelected = true,
                                 )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/components/ChartCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/components/ChartCard.kt
@@ -19,10 +19,12 @@ import androidx.compose.ui.unit.dp
 import com.oracle.visualize.R
 import com.oracle.visualize.domain.models.Chart
 import com.oracle.visualize.presentation.components.ChartRenderGeneral
+import com.oracle.visualize.ui.theme.ChartPalette
 
 @Composable
 fun ChartCard(
     chart: Chart<*>,
+    chartColorTheme: ChartPalette = ChartPalette.THEME1,
     title: String,
     isSelected: Boolean,
     onSelect: () -> Unit,
@@ -88,7 +90,7 @@ fun ChartCard(
                     .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
                     .padding(16.dp)
             ) {
-                ChartRenderGeneral(chart = chart)
+                ChartRenderGeneral(chart = chart, chartColorTheme = chartColorTheme)
             }
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/shareWithTeammatesScreen/ShareWithTeammatesViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/shareWithTeammatesScreen/ShareWithTeammatesViewModel.kt
@@ -10,7 +10,7 @@ import com.oracle.visualize.domain.repositories.TeamRepository
 import com.oracle.visualize.domain.repositories.UserRepository
 import com.oracle.visualize.domain.repositories.VisualizationRepository
 import com.oracle.visualize.domain.usecases.GetUserSuggestionsUseCase
-import com.oracle.visualize.domain.usecases.UpdateSharedUsersUseCase
+import com.oracle.visualize.domain.usecases.visualization.UpdateSharedUsersUseCase
 import com.oracle.visualize.presentation.navigation.NavRoutes
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,5 +335,11 @@
     <string name="last_30_days">Last 30 days</string>
     <string name="older">Older</string>
 
+    // Chart color themes
+    <string name="chart_changed_to_theme">Changed to Theme</string>
+    <string name="chart_theme_lagoon">Lagoon</string>
+    <string name="chart_theme_sunset">Sunset</string>
+    <string name="chart_theme_harvest">Harvest</string>
+    <string name="chart_theme_petal">Petal</string>
 
 </resources>


### PR DESCRIPTION
## Summary

- Developed `GetUserChartThemeUseCase` to get a user's preferred chart color theme from Firestore.
- The chart theme is now applied on the components `ChartComponentGeneral`, `ChartComponentFullScreen`, `FeedCard`, and `ChartCard`, after the user sets his/her preferred color palette on the Profile screen.
- The 4 color palettes are consistent with the iOS lightmode in the Figma mockup.