### PR TITLE
feat: Implement Role-Based Access Control (ADMIN, WRITER, CONSUMER)

### DIFF
--- a/app/src/main/java/com/oracle/visualize/data/mapper/UserMappers.kt
+++ b/app/src/main/java/com/oracle/visualize/data/mapper/UserMappers.kt
@@ -4,7 +4,7 @@ import com.oracle.visualize.data.datasources.dtos.UserDTO
 import com.oracle.visualize.domain.models.ShareUser
 import com.oracle.visualize.domain.models.ThemePreference
 import com.oracle.visualize.domain.models.User
-import com.oracle.visualize.domain.models.UserType
+import com.oracle.visualize.domain.models.enums.UserType
 
 /**
  * Extension function to map [UserDTO] to [User] domain model.
@@ -21,7 +21,7 @@ fun UserDTO.toDomain(): User = User(
     hiddenVisualizations = hiddenVisualizations,
 
     userType = runCatching {
-        UserType.valueOf(userType)
+        UserType.valueOf(userType.trim().uppercase())
     }.getOrDefault(UserType.CONSUMER),
 
     themePreference = runCatching {

--- a/app/src/main/java/com/oracle/visualize/data/repositories/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/oracle/visualize/data/repositories/AuthRepositoryImpl.kt
@@ -48,7 +48,7 @@ class AuthRepositoryImpl @Inject constructor(
             val authUser = authUserDTO.toDomain()
 
             // 3. Persist the profile in Firestore using the raw ID (String)
-            val userDto = UserDTO(username = name, email = email)
+            val userDto = UserDTO(username = name, email = email, userType = "WRITER")
             userDatasource.saveUserProfile(authUser.uid, userDto)
 
             // 4. Return the raw entity to fulfill the contract

--- a/app/src/main/java/com/oracle/visualize/domain/models/User.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/User.kt
@@ -1,5 +1,7 @@
 package com.oracle.visualize.domain.models
 
+import com.oracle.visualize.domain.models.enums.UserType
+
 /**
  * Domain model representing a User.
  */
@@ -10,14 +12,9 @@ data class User (
     val username: String,
     val profilePictureURL: String,
     val themePreference: ThemePreference,
-    val chartTheme: String, // Pending: Check variable Type
+    val chartTheme: String,
     val hiddenVisualizations: List<String>
 )
-
-enum class UserType {
-    ADMIN, WRITER, CONSUMER
-}
-
 enum class ThemePreference {
     LIGHT, DARK, SYSTEM
 }

--- a/app/src/main/java/com/oracle/visualize/domain/models/enums/UserType.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/enums/UserType.kt
@@ -1,0 +1,16 @@
+package com.oracle.visualize.domain.models.enums
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class UserType {
+    @SerialName("ADMIN")
+    ADMIN,
+
+    @SerialName("WRITER")
+    WRITER,
+
+    @SerialName("CONSUMER")
+    CONSUMER
+}

--- a/app/src/main/java/com/oracle/visualize/domain/models/policyObjects/ThreadPermissions.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/policyObjects/ThreadPermissions.kt
@@ -1,0 +1,24 @@
+package com.oracle.visualize.domain.models
+
+import com.oracle.visualize.domain.models.enums.UserType
+
+data class ThreadPermissions(
+    val canDelete: Boolean
+) {
+    companion object {
+        operator fun invoke(
+            userType: UserType,
+            currentUserID: String,
+            visualizationOwnerID: String,
+            commentAuthorID: String
+        ): ThreadPermissions {
+            val canDelete = when {
+                userType == UserType.ADMIN -> true
+                userType == UserType.WRITER && currentUserID == visualizationOwnerID -> true
+                else -> currentUserID == commentAuthorID
+            }
+
+            return ThreadPermissions(canDelete = canDelete)
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/domain/models/policyObjects/VisualizationPermissions.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/models/policyObjects/VisualizationPermissions.kt
@@ -1,0 +1,37 @@
+package com.oracle.visualize.domain.models.policyObjects
+
+import com.oracle.visualize.domain.models.enums.UserType
+
+data class VisualizationPermissions(
+    val canDelete: Boolean,
+    val canHide: Boolean,
+    val canShare: Boolean
+) {
+    companion object {
+        operator fun invoke(
+            userType: UserType,
+            currentUserID: String,
+            authorID: String
+        ): VisualizationPermissions {
+            val isOwner = currentUserID == authorID
+
+            return when (userType) {
+                UserType.ADMIN -> VisualizationPermissions(
+                    canDelete = true,
+                    canHide = !isOwner,
+                    canShare = true
+                )
+                UserType.WRITER -> VisualizationPermissions(
+                    canDelete = isOwner,
+                    canHide = !isOwner,
+                    canShare = isOwner
+                )
+                UserType.CONSUMER -> VisualizationPermissions(
+                    canDelete = false,
+                    canHide = true,
+                    canShare = false
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/components/FeedCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/FeedCard.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.window.PopupProperties
 import com.oracle.visualize.R
 import com.oracle.visualize.domain.models.Chart
 import com.oracle.visualize.domain.models.VisualizationCard
+import com.oracle.visualize.domain.models.policyObjects.VisualizationPermissions
 import com.oracle.visualize.presentation.screens.feedScreen.components.FeedCardMenu
 import com.oracle.visualize.presentation.screens.feedScreen.components.MemberAvatarStackFeed
 import com.oracle.visualize.presentation.screens.feedScreen.components.skeletonEffect
@@ -74,6 +75,7 @@ fun FeedCard(
     chart: Chart<*>?,
     isChartLoading: Boolean,
     onLoadChartRequest: () -> Unit,
+    permissions: VisualizationPermissions,
     isDeletable: Boolean = false,
     isMenuOpen: Boolean = false,
     onMenuOpen: () -> Unit = {},
@@ -148,7 +150,9 @@ fun FeedCard(
                             properties       = PopupProperties(focusable = true)
                         ) {
                             FeedCardMenu(
-                                isDeletable         = isDeletable,
+                                canDelete           = permissions.canDelete,
+                                canHide             = permissions.canHide,
+                                canShare            = permissions.canShare,
                                 onDismiss           = onMenuDismiss,
                                 onShare             = onShare,
                                 onDeleteForEveryone = onDeleteForEveryone,

--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
@@ -1,5 +1,7 @@
 package com.oracle.visualize.presentation.navigation
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.oracle.visualize.presentation.screens.teamsScreen.TeamsPage
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -23,6 +25,7 @@ import com.oracle.visualize.presentation.screens.signupScreen.SignUpPage
 import com.oracle.visualize.presentation.screens.splashScreen.SplashPage
 import com.oracle.visualize.presentation.screens.threadsScreen.ThreadsPage
 
+@RequiresApi(Build.VERSION_CODES.R)
 @Composable
 fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) {
     NavHost(

--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
@@ -108,7 +108,9 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                 modifier      = Modifier.fillMaxSize(),
                 navController = navController,
                 onLogout      = {
-                    navController.navigate(NavRoutes.Splash)
+                    navController.navigate(NavRoutes.Splash) {
+                        popUpTo(0) { inclusive = true }
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/createEditScreen/CreateEditTeamViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/createEditScreen/CreateEditTeamViewModel.kt
@@ -3,7 +3,9 @@ package com.oracle.visualize.presentation.screens.createEditScreen
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.oracle.visualize.domain.models.enums.UserType
 import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.repositories.UserRepository
 import com.oracle.visualize.domain.usecases.team.CreateTeamUseCase
 import com.oracle.visualize.domain.usecases.GetUserSuggestionsUseCase
 import com.oracle.visualize.domain.usecases.team.GetUsersTeamsUseCase
@@ -24,6 +26,7 @@ class CreateEditTeamViewModel @Inject constructor(
     private val getUserSuggestionsUseCase: GetUserSuggestionsUseCase,
     private val getUsersTeamsUseCase: GetUsersTeamsUseCase,
     private val authRepository: AuthRepository,
+    private val userRepository: UserRepository, // INYECTAMOS USER REPOSITORY
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -35,7 +38,6 @@ class CreateEditTeamViewModel @Inject constructor(
 
     private val _searchQuery = MutableStateFlow("")
     private val teamIdArg: String? = savedStateHandle.get<String>("teamId")
-    private val userID: String = authRepository.getCurrentUserID()
 
     init {
         loadInitialData()
@@ -46,45 +48,61 @@ class CreateEditTeamViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = CreateEditTeamUiState.Loading
 
-            if (teamIdArg != null) {
-                getUsersTeamsUseCase.getTeamsUserOwns(userID).fold(
-                    onSuccess = { teams ->
-                        val team = teams.find { it.id == teamIdArg }
-                        _uiState.value = CreateEditTeamUiState.Content(
-                            teamId      = teamIdArg,
-                            teamName    = team?.name ?: "",
-                            members     = team?.members ?: emptyList(),
-                            ownerID     = userID,
-                            suggestions = emptyList()
-                        )
-                    },
-                    onFailure = { e ->
-                        _uiState.value = CreateEditTeamUiState.Error(
-                            e.message ?: "Failed to load team"
-                        )
+            try {
+                val currentUserID = authRepository.getCurrentUserID()
+                val currentUser = userRepository.getUserByUserID(currentUserID)
+
+                if (teamIdArg != null) {
+                    val ownedDeferred  = async { getUsersTeamsUseCase.getTeamsUserOwns(currentUserID) }
+                    val memberDeferred = async { getUsersTeamsUseCase.getTeamsUserIsIn(currentUserID) }
+
+                    val ownedTeams  = ownedDeferred.await().getOrNull()  ?: emptyList()
+                    val memberTeams = memberDeferred.await().getOrNull() ?: emptyList()
+
+                    val teamToEdit = (ownedTeams + memberTeams).find { it.id == teamIdArg }
+
+                    if (teamToEdit != null) {
+                        val isOwner = teamToEdit.ownerID == currentUserID
+                        val isAdmin = currentUser.userType == UserType.ADMIN
+
+                        if (isOwner || isAdmin) {
+                            _uiState.value = CreateEditTeamUiState.Content(
+                                teamId      = teamIdArg,
+                                teamName    = teamToEdit.name,
+                                members     = teamToEdit.members,
+                                ownerID     = teamToEdit.ownerID,
+                                suggestions = emptyList()
+                            )
+                        } else {
+                            _uiState.value = CreateEditTeamUiState.Error("No tienes permiso para editar este equipo.")
+                        }
+                    } else {
+                        _uiState.value = CreateEditTeamUiState.Error("No se encontró el equipo.")
                     }
-                )
-            } else {
-                val ownedDeferred  = async { getUsersTeamsUseCase.getTeamsUserOwns(userID) }
-                val memberDeferred = async { getUsersTeamsUseCase.getTeamsUserIsIn(userID) }
+                } else {
+                    val ownedDeferred  = async { getUsersTeamsUseCase.getTeamsUserOwns(currentUserID) }
+                    val memberDeferred = async { getUsersTeamsUseCase.getTeamsUserIsIn(currentUserID) }
 
-                val ownedTeams  = ownedDeferred.await().getOrNull()  ?: emptyList()
-                val memberTeams = memberDeferred.await().getOrNull() ?: emptyList()
+                    val ownedTeams  = ownedDeferred.await().getOrNull()  ?: emptyList()
+                    val memberTeams = memberDeferred.await().getOrNull() ?: emptyList()
 
-                val ownerAsUser = (ownedTeams + memberTeams)
-                    .flatMap { it.members }
-                    .firstOrNull { it.id == userID }
+                    val ownerAsUser = (ownedTeams + memberTeams)
+                        .flatMap { it.members }
+                        .firstOrNull { it.id == currentUserID }
 
-                val suggestions = (ownedTeams + memberTeams)
-                    .flatMap { it.members }
-                    .filter    { it.id != userID }
-                    .distinctBy { it.id }
+                    val suggestions = (ownedTeams + memberTeams)
+                        .flatMap { it.members }
+                        .filter    { it.id != currentUserID }
+                        .distinctBy { it.id }
 
-                _uiState.value = CreateEditTeamUiState.Content(
-                    ownerID     = userID,
-                    members     = listOfNotNull(ownerAsUser),
-                    suggestions = suggestions
-                )
+                    _uiState.value = CreateEditTeamUiState.Content(
+                        ownerID     = currentUserID,
+                        members     = listOfNotNull(ownerAsUser),
+                        suggestions = suggestions
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = CreateEditTeamUiState.Error(e.message ?: "Error al cargar la información")
             }
         }
     }
@@ -165,7 +183,6 @@ class CreateEditTeamViewModel @Inject constructor(
         }
         viewModelScope.launch {
             _uiState.value = state.copy(isSubmitting = true)
-            // ownerID must not be in membersIDs — exclude it explicitly
             val memberIDs = state.members.map { it.id }.filter { it != state.ownerID }
             val result = if (state.isEditMode)
                 updateTeamUseCase(state.teamId!!, memberIDs, state.teamName.trim())

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedUIState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedUIState.kt
@@ -2,6 +2,7 @@ package com.oracle.visualize.presentation.screens.feedScreen
 
 import com.oracle.visualize.domain.models.FeedItem
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
+import com.oracle.visualize.domain.models.policyObjects.VisualizationPermissions
 
 sealed interface FeedUiState {
 
@@ -19,6 +20,7 @@ sealed interface FeedUiState {
         val menuOpenForId: String? = null,
         val deleteDialogForId: String? = null,
         val hideDialogForId: String? = null,
+        val permissionsMap: Map<String, VisualizationPermissions> = emptyMap(),
         val isDeletableMap: Map<String, Boolean> = emptyMap(),
         val pendingShareId: String? = null
     ) : FeedUiState

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
@@ -27,7 +27,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.oracle.visualize.R
+import com.oracle.visualize.domain.models.enums.UserType
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
+import com.oracle.visualize.domain.models.policyObjects.VisualizationPermissions
 import com.oracle.visualize.presentation.components.FeedCard
 import com.oracle.visualize.presentation.components.FeedTopBar
 import com.oracle.visualize.presentation.components.SearchSection
@@ -145,7 +147,11 @@ fun FeedPage(
                                     currentUserID       = state.currentUserID,
                                     isChartLoading      = feedItem.isChartLoading,
                                     onLoadChartRequest  = { feedViewModel.loadChartForCard(feedItem.card) },
-                                    isDeletable         = state.isDeletableMap[feedItem.card.id] ?: false,
+                                    permissions         = state.permissionsMap[feedItem.card.id] ?: VisualizationPermissions(
+                                        UserType.CONSUMER,
+                                        "",
+                                        ""
+                                    ),
                                     isMenuOpen          = state.menuOpenForId == feedItem.card.id,
                                     onClick             = { onVisualizationClick(feedItem.card.id) },
                                     onMenuOpen          = { feedViewModel.onMenuOpen(feedItem.card.id) },

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -9,10 +9,10 @@ import com.oracle.visualize.domain.models.FeedItem
 import com.oracle.visualize.domain.models.VisualizationCard
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
 import com.oracle.visualize.domain.repositories.AuthRepository
-import com.oracle.visualize.domain.usecases.DeleteVisualizationForEveryoneUseCase
-import com.oracle.visualize.domain.usecases.HideVisualizationForMeUseCase
 import com.oracle.visualize.domain.usecases.ObserveUserFeedUseCase
 import com.oracle.visualize.domain.usecases.chart.ParseSingleChartUseCase
+import com.oracle.visualize.domain.usecases.visualization.DeleteVisualizationForEveryoneUseCase
+import com.oracle.visualize.domain.usecases.visualization.HideVisualizationForMeUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -7,8 +7,11 @@ import com.oracle.visualize.data.datasources.local.FeedCacheManager
 import com.oracle.visualize.domain.exceptions.AppError
 import com.oracle.visualize.domain.models.FeedItem
 import com.oracle.visualize.domain.models.VisualizationCard
+import com.oracle.visualize.domain.models.enums.UserType
 import com.oracle.visualize.domain.models.enums.VisualizationFilter
+import com.oracle.visualize.domain.models.policyObjects.VisualizationPermissions
 import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.repositories.UserRepository
 import com.oracle.visualize.domain.usecases.ObserveUserFeedUseCase
 import com.oracle.visualize.domain.usecases.chart.ParseSingleChartUseCase
 import com.oracle.visualize.domain.usecases.visualization.DeleteVisualizationForEveryoneUseCase
@@ -26,6 +29,7 @@ import javax.inject.Inject
 class FeedViewModel @Inject constructor(
     private val observeUserFeedUseCase: ObserveUserFeedUseCase,
     private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
     private val parseSingleChartUseCase: ParseSingleChartUseCase,
     private val deleteVisualizationForEveryoneUseCase: DeleteVisualizationForEveryoneUseCase,
     private val hideVisualizationForMeUseCase: HideVisualizationForMeUseCase,
@@ -37,14 +41,18 @@ class FeedViewModel @Inject constructor(
 
     private var allFeedItems: List<FeedItem> = emptyList()
     private var currentUserID: String = ""
+    private var currentUserType: UserType = UserType.CONSUMER
     private var feedJob: Job? = null
 
     init {
-        try {
-            currentUserID = authRepository.getCurrentUserID()
-            loadData(forceRefresh = false)
-        } catch (e: Exception) {
-            _uiState.value = FeedUiState.Error(R.string.error_unknown_retry)
+        viewModelScope.launch {
+            try {
+                currentUserID = authRepository.getCurrentUserID()
+                currentUserType = userRepository.getUserByUserID(currentUserID).userType
+                loadData(forceRefresh = false)
+            } catch (e: Exception) {
+                _uiState.value = FeedUiState.Error(R.string.error_unknown_retry)
+            }
         }
     }
 
@@ -214,7 +222,13 @@ class FeedViewModel @Inject constructor(
             }
         }
 
-        val isDeletableMap = filteredItems.associate { it.card.id to (it.card.authorID == currentUserID) }
+        val permissionsMap = filteredItems.associate { item ->
+            item.card.id to VisualizationPermissions(
+                userType = currentUserType,
+                currentUserID = currentUserID,
+                authorID = item.card.authorID
+            )
+        }
 
         _uiState.update {
             FeedUiState.Success(
@@ -224,7 +238,7 @@ class FeedViewModel @Inject constructor(
                 selectedFilter = filter,
                 isRefreshing   = false,
                 isSearching    = isSearching,
-                isDeletableMap = isDeletableMap
+                permissionsMap = permissionsMap
             )
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/components/FeedCardMenu.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/components/FeedCardMenu.kt
@@ -24,13 +24,13 @@ import com.oracle.visualize.R
 
 /**
  * Floating card menu displayed when the three-dot icon on a [FeedCard] is tapped.
- * Role-aware via [isDeletable]:
- * - true  (owner)     → Share + Delete for everyone
- * - false (non-owner) → Hide for me
+ * Menus are dynamically generated based on the user's role and ownership via the Policy Object.
  */
 @Composable
 fun FeedCardMenu(
-    isDeletable: Boolean,
+    canDelete: Boolean,
+    canHide: Boolean,
+    canShare: Boolean,
     onDismiss: () -> Unit,
     onShare: () -> Unit,
     onDeleteForEveryone: () -> Unit,
@@ -50,23 +50,32 @@ fun FeedCardMenu(
             .width(260.dp)
     ) {
         Column(modifier = Modifier.padding(vertical = 8.dp)) {
-            if (isDeletable) {
+
+            if (canShare) {
                 FeedCardMenuItem(
                     label   = stringResource(R.string.feed_menu_share),
                     color   = MaterialTheme.colorScheme.onPrimaryContainer,
                     onClick = { onDismiss(); onShare() }
                 )
-                HorizontalDivider(
-                    modifier  = Modifier.padding(horizontal = 16.dp),
-                    thickness = 0.5.dp,
-                    color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
-                )
+            }
+
+            if (canShare && (canDelete || canHide)) {
+                MenuDivider()
+            }
+
+            if (canDelete) {
                 FeedCardMenuItem(
                     label   = stringResource(R.string.feed_menu_delete_for_everyone),
                     color   = MaterialTheme.colorScheme.error,
                     onClick = { onDismiss(); onDeleteForEveryone() }
                 )
-            } else {
+            }
+
+            if (canDelete && canHide) {
+                MenuDivider()
+            }
+
+            if (canHide) {
                 FeedCardMenuItem(
                     label   = stringResource(R.string.feed_menu_hide_for_me),
                     color   = MaterialTheme.colorScheme.error,
@@ -78,6 +87,15 @@ fun FeedCardMenu(
 }
 
 @Composable
+private fun MenuDivider() {
+    HorizontalDivider(
+        modifier  = Modifier.padding(horizontal = 16.dp),
+        thickness = 0.5.dp,
+        color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+    )
+}
+
+@Composable
 private fun FeedCardMenuItem(label: String, color: Color, onClick: () -> Unit) {
     Box(
         modifier = Modifier
@@ -85,7 +103,12 @@ private fun FeedCardMenuItem(label: String, color: Color, onClick: () -> Unit) {
             .clickable(onClick = onClick)
             .padding(horizontal = 24.dp, vertical = 16.dp)
     ) {
-        Text(text = label, color = color, fontSize = 20.sp,
-            fontWeight = FontWeight.Normal, style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = label,
+            color = color,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Normal,
+            style = MaterialTheme.typography.bodyLarge
+        )
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
@@ -1,33 +1,40 @@
 package com.oracle.visualize.presentation.screens.mainScreen
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.oracle.visualize.presentation.components.BottomNavBar
 import com.oracle.visualize.presentation.navigation.AppNavHost
+import com.oracle.visualize.presentation.navigation.NavRoutes
 
-/**
- * Main container screen that sets up the navigation host and bottom bar.
- *
- * @param viewModel The [MainViewModel] providing navigation items.
- * Uses [AppNavHost] to manage navigation.
- */
+@RequiresApi(Build.VERSION_CODES.R)
 @Composable
 fun MainScreen(
     viewModel: MainViewModel = hiltViewModel(),
 ) {
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
+    val navItems by viewModel.navItems.collectAsStateWithLifecycle()
 
-    val currentDestination = viewModel.navItems.find { item ->
+    LaunchedEffect(backStackEntry?.destination?.route) {
+        if (backStackEntry?.destination?.hasRoute(NavRoutes.Feed::class) == true) {
+            viewModel.loadNavItems()
+        }
+    }
+
+    val currentDestination = navItems.find { item ->
         backStackEntry?.destination?.hasRoute(item.destination::class) == true
     }?.destination
 
@@ -37,9 +44,9 @@ fun MainScreen(
         modifier = Modifier.fillMaxSize(),
         contentWindowInsets = WindowInsets(0),
         bottomBar = {
-            if (showBottomBar) {
+            if (showBottomBar && navItems.isNotEmpty()) {
                 BottomNavBar(
-                    navItems = viewModel.navItems,
+                    navItems = navItems,
                     currentDestination = currentDestination,
                     onItemSelected = { destination ->
                         navController.navigate(destination) {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
@@ -29,8 +29,14 @@ fun MainScreen(
     val navItems by viewModel.navItems.collectAsStateWithLifecycle()
 
     LaunchedEffect(backStackEntry?.destination?.route) {
-        if (backStackEntry?.destination?.hasRoute(NavRoutes.Feed::class) == true) {
+        val isFeed = backStackEntry?.destination?.hasRoute(NavRoutes.Feed::class) == true
+        val isSplash = backStackEntry?.destination?.hasRoute(NavRoutes.Splash::class) == true
+        val isLogin = backStackEntry?.destination?.hasRoute(NavRoutes.Login::class) == true
+
+        if (isFeed) {
             viewModel.loadNavItems()
+        } else if (isSplash || isLogin) {
+            viewModel.clearState()
         }
     }
 

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainViewModel.kt
@@ -29,8 +29,6 @@ class MainViewModel @Inject constructor(
 
     private val _navItems = MutableStateFlow<List<NavItem>>(emptyList())
     val navItems: StateFlow<List<NavItem>> = _navItems.asStateFlow()
-
-    // Variable para rastrear qué usuario cargó la barra y evitar recargas innecesarias
     private var lastLoadedUserId: String? = null
 
     init {
@@ -86,5 +84,10 @@ class MainViewModel @Inject constructor(
                 e.printStackTrace()
             }
         }
+    }
+
+    fun clearState() {
+        _navItems.value = emptyList()
+        lastLoadedUserId = null
     }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainViewModel.kt
@@ -7,49 +7,84 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Person
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.oracle.visualize.R
+import com.oracle.visualize.domain.models.enums.UserType
+import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.repositories.UserRepository
 import com.oracle.visualize.presentation.navigation.NavItem
 import com.oracle.visualize.presentation.navigation.NavRoutes
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-/**
- * ViewModel for the Main screen (container for bottom navigation).
- * Provides the list of navigation items.
- */
 @HiltViewModel
-class MainViewModel @Inject constructor() : ViewModel() {
+class MainViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository
+) : ViewModel() {
 
-    /**
-     * The list of navigation items to be displayed in the main UI.
-     * The NavController (UI layer) will use the 'destination.route' for actual navigation.
-     */
-    val navItems = listOf(
-        NavItem(
-            label = R.string.nav_create,
-            icon  = Icons.Default.Add,
-            destination = NavRoutes.Create
-        ),
-        NavItem(
-            label = R.string.nav_teams,
-            icon  = Icons.Default.Groups,
-            destination = NavRoutes.Teams
-        ),
-        NavItem(
-            label = R.string.nav_feed,
-            icon  = Icons.Default.Home,
-            destination = NavRoutes.Feed
-        ),
-        NavItem(
-            label = R.string.nav_notifications,
-            icon  = Icons.Default.Notifications,
-            badgeCount = 5,
-            destination = NavRoutes.Notifications
-        ),
-        NavItem(
-            label = R.string.nav_profile,
-            icon  = Icons.Default.Person,
-            destination = NavRoutes.Profile(userId = "placeholder") // Needs to be changed to the current user ID
-        )
-    )
+    private val _navItems = MutableStateFlow<List<NavItem>>(emptyList())
+    val navItems: StateFlow<List<NavItem>> = _navItems.asStateFlow()
+
+    // Variable para rastrear qué usuario cargó la barra y evitar recargas innecesarias
+    private var lastLoadedUserId: String? = null
+
+    init {
+        loadNavItems()
+    }
+
+    fun loadNavItems() {
+        viewModelScope.launch {
+            try {
+                val currentUserID = authRepository.getCurrentUserID()
+                if (currentUserID.isBlank()) return@launch
+                if (currentUserID == lastLoadedUserId && _navItems.value.isNotEmpty()) return@launch
+
+                val currentUser = userRepository.getUserByUserID(currentUserID)
+                lastLoadedUserId = currentUserID
+                val items = mutableListOf(
+                    NavItem(
+                        label = R.string.nav_teams,
+                        icon  = Icons.Default.Groups,
+                        destination = NavRoutes.Teams
+                    ),
+                    NavItem(
+                        label = R.string.nav_feed,
+                        icon  = Icons.Default.Home,
+                        destination = NavRoutes.Feed
+                    ),
+                    NavItem(
+                        label = R.string.nav_notifications,
+                        icon  = Icons.Default.Notifications,
+                        badgeCount = 5,
+                        destination = NavRoutes.Notifications
+                    ),
+                    NavItem(
+                        label = R.string.nav_profile,
+                        icon  = Icons.Default.Person,
+                        destination = NavRoutes.Profile(userId = currentUserID)
+                    )
+                )
+
+                if (currentUser.userType != UserType.CONSUMER) {
+                    items.add(
+                        0,
+                        NavItem(
+                            label = R.string.nav_create,
+                            icon  = Icons.Default.Add,
+                            destination = NavRoutes.Create
+                        )
+                    )
+                }
+
+                _navItems.value = items
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainViewModel.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.oracle.visualize.R
+import com.oracle.visualize.domain.exceptions.AppResult
 import com.oracle.visualize.domain.models.enums.UserType
 import com.oracle.visualize.domain.repositories.AuthRepository
 import com.oracle.visualize.domain.repositories.UserRepository
@@ -38,11 +39,16 @@ class MainViewModel @Inject constructor(
     fun loadNavItems() {
         viewModelScope.launch {
             try {
-                val currentUserID = authRepository.getCurrentUserID()
+                val currentUserID = authRepository.getCurrentUserID() ?: ""
+
                 if (currentUserID.isBlank()) return@launch
                 if (currentUserID == lastLoadedUserId && _navItems.value.isNotEmpty()) return@launch
+                val userResult = userRepository.getUserByUserID(currentUserID)
+                val currentUserType = when (userResult) {
+                    is AppResult.Success -> userResult.data.userType
+                    is AppResult.Error -> UserType.CONSUMER
+                }
 
-                val currentUser = userRepository.getUserByUserID(currentUserID)
                 lastLoadedUserId = currentUserID
                 val items = mutableListOf(
                     NavItem(
@@ -67,8 +73,7 @@ class MainViewModel @Inject constructor(
                         destination = NavRoutes.Profile(userId = currentUserID)
                     )
                 )
-
-                if (currentUser.userType != UserType.CONSUMER) {
+                if (currentUserType != UserType.CONSUMER) {
                     items.add(
                         0,
                         NavItem(

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/shareWithTeammatesScreen/ShareWithTeammatesViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/shareWithTeammatesScreen/ShareWithTeammatesViewModel.kt
@@ -10,7 +10,7 @@ import com.oracle.visualize.domain.repositories.TeamRepository
 import com.oracle.visualize.domain.repositories.UserRepository
 import com.oracle.visualize.domain.repositories.VisualizationRepository
 import com.oracle.visualize.domain.usecases.GetUserSuggestionsUseCase
-import com.oracle.visualize.domain.usecases.UpdateSharedUsersUseCase
+import com.oracle.visualize.domain.usecases.visualization.UpdateSharedUsersUseCase
 import com.oracle.visualize.presentation.navigation.NavRoutes
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamUiState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamUiState.kt
@@ -1,6 +1,7 @@
 package com.oracle.visualize.presentation.screens.teamsScreen
 
 import com.oracle.visualize.domain.models.ShareTeam
+import com.oracle.visualize.domain.models.enums.UserType
 
 /**
  * Represents the UI state of the Teams screen.
@@ -14,8 +15,8 @@ sealed interface TeamsUiState {
         val teamsImIn: List<ShareTeam> = emptyList(),
         val expandedTeamIds: Set<String> = emptySet(),
         val swipedTeamId: String? = null,
-        // Non-null while the delete confirmation dialog is visible
-        val teamPendingDeleteId: String? = null
+        val teamPendingDeleteId: String? = null,
+        val userType: UserType = UserType.CONSUMER
     ) : TeamsUiState
 
     data class Error(val message: String) : TeamsUiState

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamsView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamsView.kt
@@ -120,7 +120,7 @@ private fun TeamsContent(
                             text       = stringResource(R.string.teams_my_teams_section),
                             fontSize   = 24.sp,
                             fontWeight = FontWeight.Normal,
-                            color      = subtitleTextColors, // Color dinámico
+                            color      = subtitleTextColors,
                             modifier   = Modifier.padding(bottom = 12.dp)
                         )
                     }
@@ -150,7 +150,7 @@ private fun TeamsContent(
                         text       = stringResource(R.string.teams_im_in_section),
                         fontSize   = 24.sp,
                         fontWeight = FontWeight.Normal,
-                        color      = subtitleTextColors, // Color dinámico
+                        color      = subtitleTextColors,
                         modifier   = Modifier.padding(bottom = 12.dp)
                     )
                 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamsView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamsView.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.oracle.visualize.R
+import com.oracle.visualize.domain.models.enums.UserType
 import com.oracle.visualize.presentation.screens.teamsScreen.components.DeleteTeamDialog
 import com.oracle.visualize.presentation.screens.teamsScreen.components.TeamPosition
 import com.oracle.visualize.presentation.screens.teamsScreen.components.TeamsImInRow
@@ -88,6 +89,9 @@ private fun TeamsContent(
     modifier: Modifier = Modifier,
     onEvent: (TeamsUiEvent) -> Unit
 ) {
+    val isConsumer = state.userType == UserType.CONSUMER
+    val isAdmin = state.userType == UserType.ADMIN
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -103,33 +107,37 @@ private fun TeamsContent(
                     .padding(horizontal = 16.dp),
                 contentPadding = PaddingValues(bottom = 120.dp)
             ) {
-                item {
-                    Spacer(modifier = Modifier.height(24.dp))
-                    Text(
-                        text       = stringResource(R.string.teams_my_teams_section),
-                        fontSize   = 24.sp,
-                        fontWeight = FontWeight.Normal,
-                        color      = MaterialTheme.colorScheme.onSurface,
-                        modifier   = Modifier.padding(bottom = 12.dp)
-                    )
-                }
 
-                itemsIndexed(state.myTeams) { index, team ->
-                    MyTeamRow(
-                        team           = team,
-                        isSwiped       = state.swipedTeamId == team.id,
-                        position       = when {
-                            state.myTeams.size == 1         -> TeamPosition.SINGLE
-                            index == 0                      -> TeamPosition.TOP
-                            index == state.myTeams.size - 1 -> TeamPosition.BOTTOM
-                            else                            -> TeamPosition.MIDDLE
-                        },
-                        onSwipe        = { onEvent(TeamsUiEvent.SwipeTeam(team.id)) },
-                        onDismissSwipe = { onEvent(TeamsUiEvent.SwipeTeam(null)) },
-                        onEdit         = { onEvent(TeamsUiEvent.NavigateToEditTeam(team.id)) },
-                        onDelete       = { onEvent(TeamsUiEvent.RequestDeleteTeam(team.id)) }
-                    )
-                    if (index < state.myTeams.size - 1) Spacer(modifier = Modifier.height(3.dp))
+                // === SECCIÓN MIS EQUIPOS (Oculto para CONSUMER) ===
+                if (!isConsumer) {
+                    item {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Text(
+                            text       = stringResource(R.string.teams_my_teams_section),
+                            fontSize   = 24.sp,
+                            fontWeight = FontWeight.Normal,
+                            color      = MaterialTheme.colorScheme.onSurface,
+                            modifier   = Modifier.padding(bottom = 12.dp)
+                        )
+                    }
+
+                    itemsIndexed(state.myTeams) { index, team ->
+                        MyTeamRow(
+                            team           = team,
+                            isSwiped       = state.swipedTeamId == team.id,
+                            position       = when {
+                                state.myTeams.size == 1         -> TeamPosition.SINGLE
+                                index == 0                      -> TeamPosition.TOP
+                                index == state.myTeams.size - 1 -> TeamPosition.BOTTOM
+                                else                            -> TeamPosition.MIDDLE
+                            },
+                            onSwipe        = { onEvent(TeamsUiEvent.SwipeTeam(team.id)) },
+                            onDismissSwipe = { onEvent(TeamsUiEvent.SwipeTeam(null)) },
+                            onEdit         = { onEvent(TeamsUiEvent.NavigateToEditTeam(team.id)) },
+                            onDelete       = { onEvent(TeamsUiEvent.RequestDeleteTeam(team.id)) }
+                        )
+                        if (index < state.myTeams.size - 1) Spacer(modifier = Modifier.height(3.dp))
+                    }
                 }
 
                 item {
@@ -144,33 +152,49 @@ private fun TeamsContent(
                 }
 
                 itemsIndexed(state.teamsImIn) { index, team ->
-                    TeamsImInRow(
-                        team       = team,
-                        isExpanded = team.id in state.expandedTeamIds,
-                        position   = when {
-                            state.teamsImIn.size == 1         -> TeamPosition.SINGLE
-                            index == 0                        -> TeamPosition.TOP
-                            index == state.teamsImIn.size - 1 -> TeamPosition.BOTTOM
-                            else                              -> TeamPosition.MIDDLE
-                        },
-                        onToggle   = { onEvent(TeamsUiEvent.ToggleExpand(team.id)) }
-                    )
+                    val position = when {
+                        state.teamsImIn.size == 1         -> TeamPosition.SINGLE
+                        index == 0                        -> TeamPosition.TOP
+                        index == state.teamsImIn.size - 1 -> TeamPosition.BOTTOM
+                        else                              -> TeamPosition.MIDDLE
+                    }
+
+                    if (isAdmin) {
+                        MyTeamRow(
+                            team           = team,
+                            isSwiped       = state.swipedTeamId == team.id,
+                            position       = position,
+                            onSwipe        = { onEvent(TeamsUiEvent.SwipeTeam(team.id)) },
+                            onDismissSwipe = { onEvent(TeamsUiEvent.SwipeTeam(null)) },
+                            onEdit         = { onEvent(TeamsUiEvent.NavigateToEditTeam(team.id)) },
+                            onDelete       = { onEvent(TeamsUiEvent.RequestDeleteTeam(team.id)) }
+                        )
+                    } else {
+                        TeamsImInRow(
+                            team       = team,
+                            isExpanded = team.id in state.expandedTeamIds,
+                            position   = position,
+                            onToggle   = { onEvent(TeamsUiEvent.ToggleExpand(team.id)) }
+                        )
+                    }
+
                     if (index < state.teamsImIn.size - 1) Spacer(modifier = Modifier.height(3.dp))
                 }
             }
         }
-
-        FloatingActionButton(
-            onClick        = { onEvent(TeamsUiEvent.NavigateToCreateTeam) },
-            modifier       = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(bottom = 32.dp, end = 24.dp)
-                .size(80.dp),
-            containerColor = MaterialTheme.colorScheme.secondary,
-            contentColor   = MaterialTheme.colorScheme.onSecondary,
-            shape          = RoundedCornerShape(24.dp)
-        ) {
-            Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.teams_create_fab_description), modifier = Modifier.size(40.dp))
+        if (!isConsumer) {
+            FloatingActionButton(
+                onClick        = { onEvent(TeamsUiEvent.NavigateToCreateTeam) },
+                modifier       = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(bottom = 32.dp, end = 24.dp)
+                    .size(80.dp),
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor   = MaterialTheme.colorScheme.onSecondary,
+                shape          = RoundedCornerShape(24.dp)
+            ) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.teams_create_fab_description), modifier = Modifier.size(40.dp))
+            }
         }
 
         if (state.teamPendingDeleteId != null) {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamsViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/teamsScreen/TeamsViewModel.kt
@@ -3,6 +3,7 @@ package com.oracle.visualize.presentation.screens.teamsScreen
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.repositories.UserRepository
 import com.oracle.visualize.domain.usecases.team.DeleteTeamUseCase
 import com.oracle.visualize.domain.usecases.team.GetUsersTeamsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,40 +17,42 @@ import javax.inject.Inject
 class TeamsViewModel @Inject constructor(
     private val getUsersTeamsUseCase: GetUsersTeamsUseCase,
     private val deleteTeamUseCase: DeleteTeamUseCase,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TeamsUiState>(TeamsUiState.Loading)
     val uiState: StateFlow<TeamsUiState> = _uiState.asStateFlow()
-
-    private val userID: String = authRepository.getCurrentUserID()
-
     init { loadTeams() }
 
     private fun loadTeams() {
         viewModelScope.launch {
             _uiState.value = TeamsUiState.Loading
 
-            val myTeamsResult   = getUsersTeamsUseCase.getTeamsUserOwns(userID)
-            val teamsImInResult = getUsersTeamsUseCase.getTeamsUserIsIn(userID)
+            try {
+                val userID = authRepository.getCurrentUserID()
+                val currentUser = userRepository.getUserByUserID(userID)
 
-            if (myTeamsResult.isFailure) {
-                _uiState.value = TeamsUiState.Error(
-                    myTeamsResult.exceptionOrNull()?.message ?: "Failed to load teams"
-                )
-                return@launch
-            }
-            if (teamsImInResult.isFailure) {
-                _uiState.value = TeamsUiState.Error(
-                    teamsImInResult.exceptionOrNull()?.message ?: "Failed to load teams"
-                )
-                return@launch
-            }
+                val myTeamsResult   = getUsersTeamsUseCase.getTeamsUserOwns(userID)
+                val teamsImInResult = getUsersTeamsUseCase.getTeamsUserIsIn(userID)
 
-            _uiState.value = TeamsUiState.Content(
-                myTeams   = myTeamsResult.getOrDefault(emptyList()),
-                teamsImIn = teamsImInResult.getOrDefault(emptyList())
-            )
+                if (myTeamsResult.isFailure) {
+                    _uiState.value = TeamsUiState.Error(myTeamsResult.exceptionOrNull()?.message ?: "Failed to load teams")
+                    return@launch
+                }
+                if (teamsImInResult.isFailure) {
+                    _uiState.value = TeamsUiState.Error(teamsImInResult.exceptionOrNull()?.message ?: "Failed to load teams")
+                    return@launch
+                }
+
+                _uiState.value = TeamsUiState.Content(
+                    myTeams   = myTeamsResult.getOrDefault(emptyList()),
+                    teamsImIn = teamsImInResult.getOrDefault(emptyList()),
+                    userType  = currentUser.userType
+                )
+            } catch (e: Exception) {
+                _uiState.value = TeamsUiState.Error(e.message ?: "Failed to load user info")
+            }
         }
     }
 

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/ThreadsUIState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/ThreadsUIState.kt
@@ -1,10 +1,12 @@
 package com.oracle.visualize.presentation.screens.threadsScreen
 
+import com.oracle.visualize.domain.models.ThreadPermissions
 import java.util.Date
 
 data class ThreadsUIState(
     val isLoading: Boolean = false,
     val visualizationTitle: String = "",
+    val visualizationOwnerID: String = "",
     val currentUserId: String = "",
     val comments: List<CommentUiModel> = emptyList(),
     val errorMessage: Int? = null,
@@ -20,7 +22,8 @@ data class CommentUiModel(
     val content: String,
     val imageURL: String?,
     val createdAt: Date,
-    val threads: List<ThreadUiModel> = emptyList()
+    val threads: List<ThreadUiModel> = emptyList(),
+    val permissions: ThreadPermissions
 )
 
 data class ThreadUiModel(
@@ -29,5 +32,6 @@ data class ThreadUiModel(
     val authorName: String,
     val authorImageURL: String?,
     val content: String,
-    val createdAt: Date
+    val createdAt: Date,
+    val permissions: ThreadPermissions
 )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/ThreadsViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/ThreadsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.oracle.visualize.R
 import com.oracle.visualize.domain.exceptions.AppError
 import com.oracle.visualize.domain.exceptions.AppResult
+import com.oracle.visualize.domain.models.ThreadPermissions
+import com.oracle.visualize.domain.models.enums.UserType
 import com.oracle.visualize.domain.repositories.AuthRepository
 import com.oracle.visualize.domain.repositories.UserRepository
 import com.oracle.visualize.domain.usecases.comment.CreateCommentUseCase
@@ -41,6 +43,7 @@ class ThreadsViewModel @Inject constructor(
     private var currentUserID: String = ""
     private var currentUserName: String = ""
     private var currentUserImageUrl: String? = null
+    private var currentUserType: UserType = UserType.CONSUMER
 
     init {
         currentUserID = authRepository.getCurrentUserID() ?: ""
@@ -50,6 +53,7 @@ class ThreadsViewModel @Inject constructor(
                 is AppResult.Success -> {
                     currentUserName = result.data.username ?: currentUserID
                     currentUserImageUrl = result.data.profilePictureURL
+                    currentUserType = result.data.userType
                 }
                 is AppResult.Error -> {
                     currentUserName = currentUserID
@@ -75,9 +79,11 @@ class ThreadsViewModel @Inject constructor(
 
         viewModelScope.launch {
             val visualizationsResult = getAllUserVisualizationsUseCase(currentUserID)
-            val visualizationTitle = if (visualizationsResult is AppResult.Success) {
-                visualizationsResult.data.find { it.id == visualizationId }?.title ?: ""
-            } else ""
+            val visualization = if (visualizationsResult is AppResult.Success) {
+                visualizationsResult.data.find { it.id == visualizationId }
+            } else null
+            val visualizationTitle = visualization?.title ?: ""
+            val visualizationOwnerID = visualization?.authorID ?: ""
 
             when (val commentsResult = getCommentsUseCase(visualizationId)) {
                 is AppResult.Success -> {
@@ -96,7 +102,13 @@ class ThreadsViewModel @Inject constructor(
                                 authorName = thread.authorName.ifBlank { threadAuthor.first },
                                 authorImageURL = thread.authorAvatarURL ?: threadAuthor.second,
                                 content = thread.content,
-                                createdAt = thread.createdAt
+                                createdAt = thread.createdAt,
+                                permissions = ThreadPermissions(
+                                    userType = currentUserType,
+                                    currentUserID = currentUserID,
+                                    visualizationOwnerID = visualizationOwnerID,
+                                    commentAuthorID = thread.authorID
+                                )
                             )
                         }
 
@@ -108,13 +120,20 @@ class ThreadsViewModel @Inject constructor(
                             content = comment.content,
                             imageURL = comment.imageURL,
                             createdAt = comment.createdAt,
-                            threads = threadsUi
+                            threads = threadsUi,
+                            permissions = ThreadPermissions(
+                                userType = currentUserType,
+                                currentUserID = currentUserID,
+                                visualizationOwnerID = visualizationOwnerID,
+                                commentAuthorID = comment.authorID
+                            )
                         )
                     }
                     _uiState.update {
                         it.copy(
                             isLoading = false,
                             visualizationTitle = visualizationTitle,
+                            visualizationOwnerID = visualizationOwnerID,
                             currentUserId = currentUserID,
                             comments = commentsUi
                         )
@@ -169,7 +188,13 @@ class ThreadsViewModel @Inject constructor(
                         content = newComment.content,
                         imageURL = newComment.imageURL,
                         createdAt = newComment.createdAt,
-                        threads = emptyList()
+                        threads = emptyList(),
+                        permissions = ThreadPermissions(
+                            userType = currentUserType,
+                            currentUserID = currentUserID,
+                            visualizationOwnerID = _uiState.value.visualizationOwnerID,
+                            commentAuthorID = currentUserID
+                        )
                     )
 
                     _uiState.update {
@@ -216,7 +241,13 @@ class ThreadsViewModel @Inject constructor(
                         authorName = newThread.authorName,
                         authorImageURL = newThread.authorAvatarURL,
                         content = newThread.content,
-                        createdAt = newThread.createdAt
+                        createdAt = newThread.createdAt,
+                        permissions = ThreadPermissions(
+                            userType = currentUserType,
+                            currentUserID = currentUserID,
+                            visualizationOwnerID = _uiState.value.visualizationOwnerID,
+                            commentAuthorID = currentUserID
+                        )
                     )
                     _uiState.update { state ->
                         state.copy(

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/components/CommentCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/components/CommentCard.kt
@@ -27,6 +27,7 @@ import com.oracle.visualize.presentation.components.UserAvatar
 import com.oracle.visualize.presentation.screens.threadsScreen.CommentUiModel
 import java.text.SimpleDateFormat
 import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @Composable
 fun CommentCard(
@@ -54,7 +55,7 @@ fun CommentCard(
 
     val formattedDate = SimpleDateFormat(
         "dd/MM/yy",
-        Locale.getDefault()
+        LocalLocale.current.platformLocale
     ).format(comment.createdAt)
 
     var expanded by remember { mutableStateOf(false) }
@@ -96,7 +97,7 @@ fun CommentCard(
                     color = MaterialTheme.colorScheme.onBackground
                 )
             }
-            if (isCurrentUser) {
+            if (comment.permissions.canDelete) {
                 Box {
                     IconButton(
                         onClick = {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/components/ThreadCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/threadsScreen/components/ThreadCard.kt
@@ -29,6 +29,7 @@ import com.oracle.visualize.presentation.components.UserAvatar
 import com.oracle.visualize.presentation.screens.threadsScreen.ThreadUiModel
 import java.text.SimpleDateFormat
 import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -40,7 +41,7 @@ fun ThreadCard(
 ) {
     val formattedDate = SimpleDateFormat(
         "dd/MM/yy",
-        Locale.getDefault()
+        LocalLocale.current.platformLocale
     ).format(thread.createdAt)
 
     var expanded by remember { mutableStateOf(false) }
@@ -51,7 +52,7 @@ fun ThreadCard(
             .combinedClickable(
                 onClick = {},
                 onLongClick = {
-                    if (isCurrentUser) {
+                    if (thread.permissions.canDelete) {
                         expanded = true
                     }
                 }


### PR DESCRIPTION
## Overview
This Pull Request introduces comprehensive Role-Based Access Control (RBAC) across the application. It defines and enforces permissions for `ADMIN`, `WRITER`, and `CONSUMER` roles, ensuring that users only see and interact with UI elements and actions they have authorization for. 

## Key Features & Changes

### Navigation & UI
* **NavBar Role Enforcement:** The "Create visualizations" section (`+` button) is now hidden when the logged-in user is a `CONSUMER`.
* **Teams Screen:** Implemented role-aware UI rendering. The view now adapts based on whether the user is an Admin, Writer, or Consumer (e.g., hiding creation tools or management options for consumers).

### Visualizations
* **Action Permissions:** Added strict role checks for interacting with visualizations. Sharing, deleting, and hiding actions on the Feed/Visualization cards are now governed by the user's role and ownership status.

### Threads & Comments
* **Discussion Moderation:** Implemented `ADMIN`, `WRITER`, and `CONSUMER` permissions within the comments and threads sections. Admins and visualization Owners (Writers) now have appropriate controls over comment moderation and deletion.

##  Bug Fixes & Chores
* **MainViewModel Fix:** Added an Elvis operator `?:` to the `getCurrentUserId` function to safely handle potential null user IDs and prevent crashes.
* **Branch Sync:** Successfully merged `develop` into `feature/roles` to keep the branch up to date with the latest base changes.