### PR TITLE
fix: bug where Account A's feed card where being persisted when logging into Account B

### DIFF
--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
@@ -116,7 +116,9 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                 navController = navController,
                 onLogout      = {
                     navController.navigate(NavRoutes.Splash) {
-                        popUpTo(0) { inclusive = true }
+                        popUpTo(navController.graph.id) {
+                            inclusive = true
+                        }
                     }
                 }
             )
@@ -184,7 +186,9 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                 modifier              = Modifier.fillMaxSize(),
                 onLoginSuccess        = {
                     navController.navigate(NavRoutes.Feed) {
-                        popUpTo(NavRoutes.Login) { inclusive = true }
+                        popUpTo(navController.graph.id) {
+                            inclusive = true
+                        }
                     }
                 },
                 onSignUpClick         = { navController.navigate(NavRoutes.Signup) },
@@ -197,7 +201,9 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                 modifier        = Modifier.fillMaxSize(),
                 onSignUpSuccess = {
                     navController.navigate(NavRoutes.Feed) {
-                        popUpTo(NavRoutes.Splash) { inclusive = true }
+                        popUpTo(navController.graph.id) {
+                            inclusive = true
+                        }
                     }
                 },
                 onLoginClick    = {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -168,7 +168,25 @@ class FeedViewModel @Inject constructor(
      * forces a full reload so the feed reflects the latest shared users immediately.
      */
     fun refreshIfCacheInvalidated() {
-        if (feedCacheManager.cachedFeed == null) {
+        val freshUserID = authRepository.getCurrentUserID() ?: ""
+
+        if (freshUserID.isNotBlank() && freshUserID != currentUserID) {
+            currentUserID = freshUserID
+
+            viewModelScope.launch {
+                when (val userResult = userRepository.getUserByUserID(currentUserID)) {
+                    is AppResult.Success -> {
+                        currentUserType = userResult.data.userType
+                        loadData(forceRefresh = true)
+                    }
+                    is AppResult.Error -> {
+                        updateSuccess { it }
+                        _uiState.value = FeedUiState.Error(R.string.error_unknown_retry)
+                    }
+                }
+            }
+        }
+        else if (feedCacheManager.cachedFeed == null) {
             loadData(forceRefresh = true)
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/profileScreen/ProfileView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/profileScreen/ProfileView.kt
@@ -129,8 +129,9 @@ fun ProfilePage(
             confirm = stringResource(R.string.log_out),
             cancel = stringResource(R.string.cancel),
             onConfirm = {
-                profileViewModel.logout()
-                onLogout()
+                profileViewModel.logout(onLogoutComplete = {
+                    onLogout()
+                })
                 showLogoutDialog = false
             },
             onDismiss = { showLogoutDialog = false }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/profileScreen/ProfileViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/profileScreen/ProfileViewModel.kt
@@ -115,11 +115,12 @@ class ProfileViewModel @Inject constructor(
     }
 
 
-    fun logout() {
+    fun logout(onLogoutComplete: () -> Unit) {
         viewModelScope.launch {
             logoutUseCase()
             clearFeedCacheUseCase()
             clearChartCacheUseCase()
+            onLogoutComplete()
         }
     }
 


### PR DESCRIPTION
## 📋 Description
This PR resolves a critical session data leakage bug where user visualizations from a previously logged-in account (Account A) persisted and leaked into a newly logged-in account (Account B) upon navigating back and forth between the Feed and Profile screens.

### 🔍 Root Cause
The application uses Jetpack Compose **Type-Safe Navigation**. In `AppNavHost.kt`, the `onLogout` lambda attempted to clear the backstack using `popUpTo(0) { inclusive = true }`. In type-safe navigation, passing an integer `0` causes the NavController to look for a literal route named "0", failing silently without actually popping any destinations. Because the backstack wasn't cleared, the `FeedViewModel` survived the logout/login transition as a retained instance, keeping the old `currentUserID` in memory.

### 🛠️ Changes Implemented
* **`AppNavHost.kt`**: Replaced `popUpTo(0)` with `popUpTo(navController.graph.id) { inclusive = true }` inside the `ProfilePage` destination's `onLogout` callback to properly clear the entire navigation graph.
* **`AppNavHost.kt`**: Updated `onLoginSuccess` and `onSignUpSuccess` to also clear the backstack up to `navController.graph.id`, ensuring that the `Feed` screen starts as a clean root destination without lingering `Splash`, `Login`, or `Signup` views beneath it.
* FeedViewModel.kt: Enhanced the refreshIfCacheInvalidated() function. It now dynamically checks if the current user ID has changed compared to the one stored in the ViewModel's memory. If a discrepancy is detected, it updates the ID and forces a data reload. This acts as a safety net in case future navigation changes accidentally cause the ViewModel to survive again.

## 🧪 How Has This Been Tested?
Tested locally adhering to the regression testing scenario:
1. Logged into Account A (`test@dev.com`), verified personal visualizations ("by me") loaded correctly.
2. Navigated to Profile and clicked Logout.
3. Without closing the app, logged into Account B (`patricio@lobo.com`).
4. Confirmed that Account B initially showed its own feed.
5. Navigated to Profile, then returned back to the Feed.
6. **Result**: Verified that the feed strictly displays Account B's visualizations. Account A's data no longer leaks into the session.