### PR TITLE
Snipping tool QoL changes.

### DIFF
--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
@@ -24,6 +24,7 @@ import com.oracle.visualize.presentation.screens.shareScreen.ShareAndPostScreen
 import com.oracle.visualize.presentation.screens.signupScreen.SignUpPage
 import com.oracle.visualize.presentation.screens.splashScreen.SplashPage
 import com.oracle.visualize.presentation.screens.threadsScreen.ThreadsPage
+import com.oracle.visualize.presentation.screens.snippingTool.SnippingToolView
 
 /**
  * The main navigation host for the application.
@@ -136,6 +137,13 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                             snipUri         = uri
                         )
                     )
+                },
+                onSnippingClick = { chart ->
+                    navController.navigate(
+                        NavRoutes.SnippingTool(
+                            visualizationId = route.visualizationId
+                        )
+                    )
                 }
             )
         }
@@ -212,6 +220,23 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
             ResetPasswordPage(
                 modifier           = Modifier.fillMaxSize(),
                 onBackToLoginClick = { navController.popBackStack() }
+            )
+        }
+
+        composable<NavRoutes.SnippingTool> { backStackEntry ->
+            val route = backStackEntry.toRoute<NavRoutes.SnippingTool>()
+            SnippingToolView(
+                modifier = Modifier.fillMaxSize(),
+                visualizationId = route.visualizationId,
+                onDone = { uri ->
+                    navController.navigate(
+                        NavRoutes.Threads(
+                            visualizationId = route.visualizationId,
+                            snipUri = uri
+                        )
+                    )
+                },
+                onCancel = { navController.popBackStack() },
             )
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/NavRoutes.kt
@@ -1,5 +1,6 @@
 package com.oracle.visualize.presentation.navigation
 
+import com.oracle.visualize.domain.models.Chart
 import kotlinx.serialization.Serializable
 
 /**
@@ -47,4 +48,8 @@ sealed interface NavRoutes {
     data class CreateEditTeam(val teamId: String? = null) : NavRoutes
     @Serializable
     object ResetPassword : NavRoutes
+
+    @Serializable
+    data class SnippingTool(val visualizationId: String) : NavRoutes
+
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.oracle.visualize.domain.models.Chart
 import com.oracle.visualize.presentation.screens.snippingTool.SnippingToolView
 import dev.shreyaspatil.capturable.capturable
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
@@ -65,7 +66,8 @@ fun FullVisualizationPage(
     viewModel: FullVisualizationViewModel = hiltViewModel(),
     onBackClick: () -> Unit,
     onThreadsClick: (String?) -> Unit = {},
-    startInSnippingMode: Boolean = false
+    startInSnippingMode: Boolean = false,
+    onSnippingClick: (String?) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var snippingBitmap by remember { mutableStateOf<Bitmap?>(null) }
@@ -95,33 +97,10 @@ fun FullVisualizationPage(
     }
 
     LaunchedEffect(startInSnippingMode, uiState.isLoading) {
-        if (startInSnippingMode && !uiState.isLoading) {
-
-            // Small delay to allow the graph startup animation to play before cropping.
-
-            delay(500)
-
-
-            val bitmap = captureController.captureAsync().await()
-            snippingBitmap = bitmap.asAndroidBitmap()
+        if (startInSnippingMode) {
+            onSnippingClick(visualizationId)
         }
     }
-
-    snippingBitmap?.let { bitmap ->
-        SnippingToolView(
-            bitmap = bitmap,
-            onDone = { result ->
-                viewModel.onSnipCompleted(result)
-                val uri = File(context.cacheDir, "snip_${System.currentTimeMillis()}.png").also { file ->
-                    file.outputStream().use { result.compress(Bitmap.CompressFormat.PNG, 100, it) }
-                }.toURI().toString()
-                onThreadsClick(uri)
-            },
-            onCancel = { snippingBitmap = null }
-        )
-        return
-    }
-
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -133,15 +112,7 @@ fun FullVisualizationPage(
             ) {
                 FloatingActionButton(
                     onClick = {
-                        scope.launch{
-                            try {
-                                val bitmap = captureController.captureAsync().await()
-                                snippingBitmap = bitmap.asAndroidBitmap()
-                                Log.d("Snipping Tool", "Bitmap")
-                            } catch (e: Exception) {
-                                Log.e("Snipping Tool", "Error capturando: ${e.message}")
-                            }
-                        }
+                        onSnippingClick(visualizationId)
                     },
                     containerColor = MaterialTheme.colorScheme.secondary
                 ) {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.ContextWrapper
 import android.graphics.Bitmap
 import android.os.Build
-import android.util.Log
 import android.view.View
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
@@ -34,18 +33,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import com.oracle.visualize.domain.models.Chart
-import com.oracle.visualize.presentation.screens.snippingTool.SnippingToolView
 import dev.shreyaspatil.capturable.capturable
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import java.io.File
 
 /**
  * Screen that displays a selected visualization in FullScreen mode.

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolUiState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolUiState.kt
@@ -2,6 +2,7 @@ package com.oracle.visualize.presentation.screens.snippingTool
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.TextUnit
 import com.oracle.visualize.domain.models.Chart
 import com.oracle.visualize.domain.models.VisualizationFullScreen
 import com.oracle.visualize.presentation.screens.snippingTool.components.DrawElement
@@ -17,6 +18,8 @@ data class SnippingToolUiState(
     val selectedColor: Color = Color.Red,
     val strokeWidth: Float = 4f,
     val isDrawingMode: Boolean = false,
+    val isItalics: Boolean = false,
+    val fontSize: Float = 16f,
     val cropRect: IntRect = IntRect(0, 0, 0, 0),
     val isCroppingMode: Boolean = false,
     val showConfirmDialog: Boolean = false,

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolUiState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolUiState.kt
@@ -2,9 +2,12 @@ package com.oracle.visualize.presentation.screens.snippingTool
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.IntRect
+import com.oracle.visualize.domain.models.Chart
+import com.oracle.visualize.domain.models.VisualizationFullScreen
 import com.oracle.visualize.presentation.screens.snippingTool.components.DrawElement
 import com.oracle.visualize.presentation.screens.snippingTool.components.DrawingTool
 import com.oracle.visualize.presentation.screens.snippingTool.components.ShapeType
+import com.oracle.visualize.ui.theme.ChartPalette
 
 data class SnippingToolUiState(
     val elements: List<DrawElement> = emptyList(),
@@ -18,5 +21,11 @@ data class SnippingToolUiState(
     val isCroppingMode: Boolean = false,
     val showConfirmDialog: Boolean = false,
     val showCancelDialog: Boolean = false,
-    val isTransformable: Boolean = true
+    val isTransformable: Boolean = true,
+
+    val isLoading: Boolean = false,
+    val visualization: VisualizationFullScreen? = null,
+    val chart: Chart<*>? = null,
+    val chartColorTheme: ChartPalette = ChartPalette.THEME1,
+    val errorMessage: Int? = null
 )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
@@ -8,18 +8,22 @@ import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,13 +51,19 @@ import com.oracle.visualize.presentation.screens.snippingTool.components.Snippin
 import kotlinx.coroutines.launch
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.oracle.visualize.R
+import com.oracle.visualize.presentation.components.ChartRenderFullScreen
+import com.oracle.visualize.presentation.screens.fullVisualizationScreen.components.ZoomableChart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 
 @Composable
 fun SnippingToolView(
-    bitmap: Bitmap,
-    onDone: (Bitmap) -> Unit,
+    visualizationId: String,
+    onDone: (String) -> Unit,
     onCancel: () ->  Unit,
     modifier: Modifier = Modifier,
     viewModel: SnippingToolViewModel = hiltViewModel()
@@ -87,6 +97,11 @@ fun SnippingToolView(
         scale = (scale * zoomChange).coerceIn(1f, 5f)
         offset += panChange
     }
+    val context = LocalContext.current
+
+    LaunchedEffect(visualizationId) {
+        viewModel.loadVisualization(visualizationId)
+    }
 
     if (uiState.showConfirmDialog) {
         AlertDialog(
@@ -100,7 +115,13 @@ fun SnippingToolView(
                 TextButton(onClick = {
                     viewModel.toggleConfirmDialog()
                     coroutineScope.launch {
-                        onDone(viewModel.confirmCrop(graphicsLayer.toImageBitmap().asAndroidBitmap()))
+                        val bitmap = viewModel.confirmCrop(graphicsLayer.toImageBitmap().asAndroidBitmap())
+                        val uri = withContext(Dispatchers.IO) {
+                            File(context.cacheDir, "snip_${System.currentTimeMillis()}.png").also { file ->
+                                file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+                            }.toURI().toString()
+                        }
+                        onDone(uri)
                     }
                 }) {
                     Text(
@@ -175,38 +196,55 @@ fun SnippingToolView(
                     drawLayer(graphicsLayer)
                 }
         ) {
-            Image(
-                bitmap = bitmap.asImageBitmap(),
-                contentDescription = null,
-                contentScale = ContentScale.Fit,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                        translationX = offset.x
-                        translationY = offset.y
-                    }
-            )
+            when {
+                uiState.isLoading -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
 
-            DrawingCanvas(
-                elements = uiState.elements,
-                selectedTool = uiState.selectedTool ?: DrawingTool.PEN,
-                selectedShape = uiState.selectedShape,
-                selectedColor = uiState.selectedColor,
-                strokeWidth = uiState.strokeWidth,
-                onAddElement = { viewModel.addElement(it) },
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                        translationX = offset.x
-                        translationY = offset.y
-                        compositingStrategy = CompositingStrategy.Offscreen
-                    },
-                isDrawingMode = uiState.isDrawingMode
-            )
+                uiState.errorMessage != null -> {
+                    Text(
+                        text = stringResource(uiState.errorMessage!!),
+                        modifier = Modifier.align(Alignment.Center),
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                uiState.chart != null -> {
+                    val chart = uiState.chart!!
+
+                    ZoomableChart(
+                        chart = chart,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                    ) {
+                        ChartRenderFullScreen(
+                            chart = chart, showAxisLabels = true, chartColorTheme = uiState.chartColorTheme
+                        )
+                    }
+
+                    DrawingCanvas(
+                        elements = uiState.elements,
+                        selectedTool = uiState.selectedTool ?: DrawingTool.PEN,
+                        selectedShape = uiState.selectedShape,
+                        selectedColor = uiState.selectedColor,
+                        strokeWidth = uiState.strokeWidth,
+                        onAddElement = { viewModel.addElement(it) },
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer {
+                                scaleX = scale
+                                scaleY = scale
+                                translationX = offset.x
+                                translationY = offset.y
+                                compositingStrategy = CompositingStrategy.Offscreen
+                            },
+                        isDrawingMode = uiState.isDrawingMode
+                    )
+                }
+            }
         }
 
         CropOverlay(

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
@@ -1,51 +1,45 @@
 package com.oracle.visualize.presentation.screens.snippingTool
 
+import android.app.Activity
+import android.content.ContextWrapper
 import android.graphics.Bitmap
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.asAndroidBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
@@ -57,11 +51,12 @@ import com.oracle.visualize.presentation.screens.snippingTool.components.Drawing
 import com.oracle.visualize.presentation.screens.snippingTool.components.SnippingToolActionBar
 import com.oracle.visualize.presentation.screens.snippingTool.components.SnippingToolbar
 import kotlinx.coroutines.launch
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.oracle.visualize.R
 import com.oracle.visualize.presentation.components.ChartRenderFullScreen
 import com.oracle.visualize.presentation.screens.fullVisualizationScreen.components.ZoomableChart
@@ -78,35 +73,26 @@ fun SnippingToolView(
     viewModel: SnippingToolViewModel = hiltViewModel()
 ) {
 
-
-
-    // TODO: Right now, the navigation bar appearing and reappearing crooks the crop. Fix this later.
-
-// DisposableEffect(Unit) {
-//     val window = (view.context as Activity).window
-//     val controller = WindowInsetsControllerCompat(window, view)
-//
-//     window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-//     controller.hide(WindowInsetsCompat.Type.systemBars())
-//     controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-//
-//     onDispose {
-//         window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-//         controller.show(WindowInsetsCompat.Type.systemBars())
-//     }
-// }
-
-
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val graphicsLayer = rememberGraphicsLayer()
     val coroutineScope = rememberCoroutineScope()
-    var scale by remember { mutableStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }
-    val transformState = rememberTransformableState { zoomChange, panChange, centroid ->
-        scale = (scale * zoomChange).coerceIn(1f, 5f)
-        offset += panChange
-    }
     val context = LocalContext.current
+
+    // Hide Android system bars to allow gesture interaction.
+    DisposableEffect(Unit) {
+        val activity = context as? Activity ?: (context as? ContextWrapper)?.baseContext as? Activity
+        val screenWindow = activity?.window
+
+        if (screenWindow != null) {
+            val insetsController = WindowInsetsControllerCompat(screenWindow, screenWindow.decorView)
+            insetsController.hide(WindowInsetsCompat.Type.systemBars())
+            insetsController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+
+            onDispose { insetsController.show(WindowInsetsCompat.Type.systemBars()) }
+        } else {
+            onDispose {}
+        }
+    }
 
     LaunchedEffect(visualizationId) {
         viewModel.loadVisualization(visualizationId)
@@ -186,24 +172,6 @@ fun SnippingToolView(
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
-                .onSizeChanged { size ->
-                    if (uiState.cropRect == IntRect.Zero) {
-                        viewModel.setCropRect(IntRect(
-                            (size.width * 0.1f).toInt(),
-                            (size.height * 0.1f).toInt(),
-                            (size.width * 0.9f).toInt(),
-                            (size.height * 0.9f).toInt()
-                        ))
-                    }
-                }
-                .then(
-                    if (uiState.isTransformable) Modifier.transformable(state = transformState)
-                    else Modifier
-                )
-                .drawWithContent {
-                    graphicsLayer.record { this@drawWithContent.drawContent() }
-                    drawLayer(graphicsLayer)
-                }
         ) {
             when {
                 uiState.isLoading -> {
@@ -239,21 +207,23 @@ fun SnippingToolView(
                                     onRedo = { viewModel.redo() }
                                 )
                                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    Button(
+                                    FilledIconButton(
                                         onClick = { viewModel.toggleCancelDialog() },
-                                        colors = ButtonDefaults.buttonColors(
+                                        colors = IconButtonDefaults.filledIconButtonColors(
                                             containerColor = MaterialTheme.colorScheme.error,
                                             contentColor = MaterialTheme.colorScheme.onError
                                         )
                                     ) {
-                                        Text("Discard")
+                                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.cancel))
                                     }
-                                    Button(onClick = { viewModel.toggleConfirmDialog() },
-                                        colors = ButtonDefaults.buttonColors(
+                                    FilledIconButton(
+                                        onClick = { viewModel.toggleConfirmDialog() },
+                                        colors = IconButtonDefaults.filledIconButtonColors(
                                             containerColor = MaterialTheme.colorScheme.secondary,
                                             contentColor = MaterialTheme.colorScheme.onSecondary
-                                        )) {
-                                        Text("Share")
+                                        )
+                                    ) {
+                                        Icon(Icons.Default.Send, contentDescription = stringResource(R.string.share))
                                     }
                                 }
                             }
@@ -264,8 +234,10 @@ fun SnippingToolView(
                                 onEraserClick = { viewModel.selectTool(DrawingTool.ERASER) },
                                 onColorClick = { color -> viewModel.setColor(color.selectedColor) },
                                 strokeWidth = uiState.strokeWidth,
+                                fontSize = uiState.fontSize,
                                 onThicknessClick = { viewModel.setStrokeWidth(it) },
                                 onTextClick = { viewModel.selectTool(DrawingTool.TEXT) },
+                                onFontSizeChange = {viewModel.setFontSize(it)},
                                 onShapeClick = { shape ->
                                     viewModel.selectTool(DrawingTool.SHAPE)
                                     viewModel.setShape(shape)
@@ -273,15 +245,21 @@ fun SnippingToolView(
                                 onCropClick = { viewModel.toggleCrop() },
                                 selectedColor = uiState.selectedColor,
                                 selectedTool = uiState.selectedTool,
+                                isItalics = uiState.isItalics,
+                                italicsToggle = { viewModel.setItalics() },
                                 cropMode = uiState.isCroppingMode,
                                 modifier = Modifier
-                                    .windowInsetsPadding(WindowInsets.statusBars)
+                                    .windowInsetsPadding(WindowInsets.navigationBars)
                             )
                         }
                     ) { innerPadding ->
                         Box(modifier = Modifier
                             .fillMaxSize()
                             .padding(innerPadding)
+                            .drawWithContent {
+                                graphicsLayer.record { this@drawWithContent.drawContent() }
+                                drawLayer(graphicsLayer)
+                            }
                         ) {
                             ZoomableChart(
                                 chart = chart,
@@ -304,20 +282,32 @@ fun SnippingToolView(
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .graphicsLayer {
-                                        scaleX = scale
-                                        scaleY = scale
-                                        translationX = offset.x
-                                        translationY = offset.y
                                         compositingStrategy = CompositingStrategy.Offscreen
                                     },
-                                isDrawingMode = uiState.isDrawingMode
+                                isDrawingMode = uiState.isDrawingMode,
+                                selectedFontSize = uiState.fontSize.sp,
+                                isItalics = uiState.isItalics
                             )
 
                             CropOverlay(
                                 cropRect = uiState.cropRect,
                                 onCropRectChange = { viewModel.setCropRect(it) },
                                 isCropDraggable = uiState.isCroppingMode,
-                                modifier = Modifier.fillMaxSize()
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .onSizeChanged { size ->
+                                        viewModel.setContainerSize(size)
+                                        if (uiState.cropRect == IntRect.Zero) {
+                                            viewModel.setCropRect(
+                                                IntRect(
+                                                    (size.width * 0.1f).toInt(),
+                                                    (size.height * 0.1f).toInt(),
+                                                    (size.width * 0.9f).toInt(),
+                                                    (size.height * 0.9f).toInt()
+                                                )
+                                            )
+                                        }
+                                    }
                             )
                         }
                     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
@@ -8,18 +8,26 @@ import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -51,6 +59,7 @@ import com.oracle.visualize.presentation.screens.snippingTool.components.Snippin
 import kotlinx.coroutines.launch
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.oracle.visualize.R
@@ -214,91 +223,105 @@ fun SnippingToolView(
                 uiState.chart != null -> {
                     val chart = uiState.chart!!
 
-                    ZoomableChart(
-                        chart = chart,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .fillMaxHeight()
-                    ) {
-                        ChartRenderFullScreen(
-                            chart = chart, showAxisLabels = true, chartColorTheme = uiState.chartColorTheme
-                        )
-                    }
-
-                    DrawingCanvas(
-                        elements = uiState.elements,
-                        selectedTool = uiState.selectedTool ?: DrawingTool.PEN,
-                        selectedShape = uiState.selectedShape,
-                        selectedColor = uiState.selectedColor,
-                        strokeWidth = uiState.strokeWidth,
-                        onAddElement = { viewModel.addElement(it) },
-                        modifier = Modifier
+                    Scaffold(
+                        containerColor = Color.Transparent,
+                        topBar = {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .windowInsetsPadding(WindowInsets.statusBars.add(WindowInsets(top = 16.dp)))
+                                    .padding(horizontal = 16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                SnippingToolActionBar(
+                                    onUndo = { viewModel.undo() },
+                                    onRedo = { viewModel.redo() }
+                                )
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Button(
+                                        onClick = { viewModel.toggleCancelDialog() },
+                                        colors = ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.error,
+                                            contentColor = MaterialTheme.colorScheme.onError
+                                        )
+                                    ) {
+                                        Text("Discard")
+                                    }
+                                    Button(onClick = { viewModel.toggleConfirmDialog() },
+                                        colors = ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.secondary,
+                                            contentColor = MaterialTheme.colorScheme.onSecondary
+                                        )) {
+                                        Text("Share")
+                                    }
+                                }
+                            }
+                        },
+                        bottomBar = {
+                            SnippingToolbar(
+                                onPenClick = { viewModel.selectTool(DrawingTool.PEN) },
+                                onEraserClick = { viewModel.selectTool(DrawingTool.ERASER) },
+                                onColorClick = { color -> viewModel.setColor(color.selectedColor) },
+                                strokeWidth = uiState.strokeWidth,
+                                onThicknessClick = { viewModel.setStrokeWidth(it) },
+                                onTextClick = { viewModel.selectTool(DrawingTool.TEXT) },
+                                onShapeClick = { shape ->
+                                    viewModel.selectTool(DrawingTool.SHAPE)
+                                    viewModel.setShape(shape)
+                                },
+                                onCropClick = { viewModel.toggleCrop() },
+                                selectedColor = uiState.selectedColor,
+                                selectedTool = uiState.selectedTool,
+                                cropMode = uiState.isCroppingMode,
+                                modifier = Modifier
+                                    .windowInsetsPadding(WindowInsets.statusBars)
+                            )
+                        }
+                    ) { innerPadding ->
+                        Box(modifier = Modifier
                             .fillMaxSize()
-                            .graphicsLayer {
-                                scaleX = scale
-                                scaleY = scale
-                                translationX = offset.x
-                                translationY = offset.y
-                                compositingStrategy = CompositingStrategy.Offscreen
-                            },
-                        isDrawingMode = uiState.isDrawingMode
-                    )
+                            .padding(innerPadding)
+                        ) {
+                            ZoomableChart(
+                                chart = chart,
+                                modifier = Modifier.fillMaxSize()
+                            ) {
+                                ChartRenderFullScreen(
+                                    chart = chart,
+                                    showAxisLabels = true,
+                                    chartColorTheme = uiState.chartColorTheme
+                                )
+                            }
+
+                            DrawingCanvas(
+                                elements = uiState.elements,
+                                selectedTool = uiState.selectedTool ?: DrawingTool.PEN,
+                                selectedShape = uiState.selectedShape,
+                                selectedColor = uiState.selectedColor,
+                                strokeWidth = uiState.strokeWidth,
+                                onAddElement = { viewModel.addElement(it) },
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .graphicsLayer {
+                                        scaleX = scale
+                                        scaleY = scale
+                                        translationX = offset.x
+                                        translationY = offset.y
+                                        compositingStrategy = CompositingStrategy.Offscreen
+                                    },
+                                isDrawingMode = uiState.isDrawingMode
+                            )
+
+                            CropOverlay(
+                                cropRect = uiState.cropRect,
+                                onCropRectChange = { viewModel.setCropRect(it) },
+                                isCropDraggable = uiState.isCroppingMode,
+                                modifier = Modifier.fillMaxSize()
+                            )
+                        }
+                    }
                 }
-            }
-        }
-
-        CropOverlay(
-            cropRect = uiState.cropRect,
-            onCropRectChange = { viewModel.setCropRect(it) },
-            isCropDraggable = uiState.isCroppingMode,
-            modifier = Modifier.fillMaxSize()
-        )
-
-        SnippingToolbar(
-            onPenClick = { viewModel.selectTool(DrawingTool.PEN) },
-            onEraserClick = { viewModel.selectTool(DrawingTool.ERASER) },
-            onColorClick = { color -> viewModel.setColor(color.selectedColor) },
-            strokeWidth = uiState.strokeWidth,
-            onThicknessClick = { viewModel.setStrokeWidth(it) },
-            onTextClick = { viewModel.selectTool(DrawingTool.TEXT) },
-            onShapeClick = { shape ->
-                viewModel.selectTool(DrawingTool.SHAPE)
-                viewModel.setShape(shape)
-            },
-            onCropClick = { viewModel.toggleCrop() },
-            selectedColor = uiState.selectedColor,
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = 16.dp, bottom = 48.dp),
-            selectedTool = uiState.selectedTool,
-            cropMode = uiState.isCroppingMode
-        )
-
-        SnippingToolActionBar(
-            onUndo = { viewModel.undo() },
-            onRedo = { viewModel.redo() },
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .padding(start = 16.dp, top = 64.dp)
-        )
-
-        Column(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(end = 16.dp, bottom = 48.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            FloatingActionButton(
-                onClick = { viewModel.toggleCancelDialog() },
-                containerColor = MaterialTheme.colorScheme.error
-            ) {
-                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.fab_cancel), tint = MaterialTheme.colorScheme.onSecondary)
-            }
-            FloatingActionButton(
-                onClick = { viewModel.toggleConfirmDialog() },
-                containerColor = MaterialTheme.colorScheme.secondary
-            ) {
-                Icon(Icons.AutoMirrored.Filled.Send, contentDescription = stringResource(R.string.fab_confirm), tint = MaterialTheme.colorScheme.onSecondary)
             }
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolViewModel.kt
@@ -5,23 +5,39 @@ import android.graphics.Bitmap
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.IntRect
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.oracle.visualize.R
+import com.oracle.visualize.domain.exceptions.AppError
+import com.oracle.visualize.domain.exceptions.AppResult
+import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.usecases.chart.GetUserChartThemeUseCase
+import com.oracle.visualize.domain.usecases.chart.ParseFullScreenChartUseCase
+import com.oracle.visualize.domain.usecases.visualization.GetIndividualVisualizationUseCase
 import com.oracle.visualize.presentation.screens.snippingTool.components.DrawElement
 import com.oracle.visualize.presentation.screens.snippingTool.components.DrawingTool
 import com.oracle.visualize.presentation.screens.snippingTool.components.ShapeType
+import com.oracle.visualize.ui.theme.ChartPalette
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SnippingToolViewModel @Inject constructor(
+    private val getIndividualVisualizationUseCase: GetIndividualVisualizationUseCase,
+    private val getUserChartThemeUseCase: GetUserChartThemeUseCase,
+    private val parseFullScreenChartUseCase: ParseFullScreenChartUseCase,
+    private val authRepository: AuthRepository,
     @ApplicationContext private val context: Context ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SnippingToolUiState())
     val uiState: StateFlow<SnippingToolUiState> = _uiState.asStateFlow()
+    private var currentUserID: String = ""
+    private var userChartTheme: ChartPalette = ChartPalette.THEME1
 
     fun addElement(element: DrawElement) {
         _uiState.update { current ->
@@ -134,6 +150,81 @@ class SnippingToolViewModel @Inject constructor(
                 isCroppingMode = false,
                 selectedTool = null
             )
+        }
+    }
+
+    fun loadVisualization(visualizationId: String) {
+        currentUserID = authRepository.getCurrentUserID() ?: ""
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    errorMessage = null
+                )
+            }
+
+            userChartTheme = when (val chartColorThemeResult = getUserChartThemeUseCase(currentUserID)){
+                is AppResult.Success -> chartColorThemeResult.data
+                is AppResult.Error -> userChartTheme
+            }
+
+            when (val result = getIndividualVisualizationUseCase(visualizationId)) {
+                is AppResult.Success -> {
+                    val visualization = result.data
+
+                    if (visualization == null) {
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                errorMessage = R.string.error_viz_not_found
+                            )
+                        }
+                    } else {
+                        when (val chartResult = parseFullScreenChartUseCase(visualization)) {
+                            is AppResult.Success -> {
+                                _uiState.update {
+                                    it.copy(
+                                        isLoading = false,
+                                        visualization = visualization,
+                                        chart = chartResult.data,
+                                        chartColorTheme = userChartTheme,
+                                        errorMessage = null
+                                    )
+                                }
+                            }
+
+                            is AppResult.Error -> {
+                                _uiState.update {
+                                    it.copy(
+                                        isLoading = false,
+                                        visualization = visualization,
+                                        chartColorTheme = userChartTheme,
+                                        errorMessage = R.string.error_chart_not_found
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                is AppResult.Error -> {
+                    val uiErrorMessage = when (result.error) {
+                        is AppError.NetworkError -> R.string.error_network
+                        is AppError.ParsingError -> R.string.error_parsing
+                        is AppError.NotFound -> R.string.error_viz_not_found
+                        else -> R.string.error_unknown_retry
+                    }
+
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            visualization = null,
+                            chartColorTheme = userChartTheme,
+                            errorMessage = uiErrorMessage
+                        )
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.oracle.visualize.R
@@ -38,6 +39,12 @@ class SnippingToolViewModel @Inject constructor(
     val uiState: StateFlow<SnippingToolUiState> = _uiState.asStateFlow()
     private var currentUserID: String = ""
     private var userChartTheme: ChartPalette = ChartPalette.THEME1
+
+    private var containerSize: IntSize = IntSize.Zero
+
+    fun setContainerSize(size: IntSize) {
+        containerSize = size
+    }
 
     fun addElement(element: DrawElement) {
         _uiState.update { current ->
@@ -80,6 +87,14 @@ class SnippingToolViewModel @Inject constructor(
         _uiState.update { it.copy(strokeWidth = width) }
     }
 
+    fun setItalics() {
+        _uiState.update { it.copy(isItalics = !it.isItalics) }
+    }
+
+    fun setFontSize(fontsize: Float) {
+        _uiState.update { it.copy(fontSize = fontsize) }
+    }
+
     fun selectTool(tool: DrawingTool) {
         _uiState.update { current ->
             if (current.isDrawingMode && current.selectedTool == tool) {
@@ -118,14 +133,14 @@ class SnippingToolViewModel @Inject constructor(
     }
 
     fun setCropRect(rect: IntRect) {
-        val screenWidth = context.resources.displayMetrics.widthPixels
-        val screenHeight = context.resources.displayMetrics.heightPixels
+        val width = containerSize.width.takeIf { it > 0 } ?: context.resources.displayMetrics.widthPixels
+        val height = containerSize.height.takeIf { it > 0 } ?: context.resources.displayMetrics.heightPixels
 
         _uiState.update { it.copy(cropRect = IntRect(
-            left = rect.left.coerceIn(0, screenWidth),
-            top = rect.top.coerceIn(0, screenHeight),
-            right = rect.right.coerceIn(0, screenWidth),
-            bottom = rect.bottom.coerceIn(0, screenHeight)
+            left = rect.left.coerceIn(0, width),
+            top = rect.top.coerceIn(0, height),
+            right = rect.right.coerceIn(0, width),
+            bottom = rect.bottom.coerceIn(0, height)
         ))}
     }
 

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/DrawingCanvas.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/DrawingCanvas.kt
@@ -29,10 +29,12 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import kotlin.math.abs
 import kotlin.math.atan2
@@ -49,6 +51,8 @@ fun DrawingCanvas(
     selectedShape: ShapeType,
     selectedColor: Color,
     strokeWidth: Float,
+    selectedFontSize: TextUnit,
+    isItalics: Boolean,
     isDrawingMode: Boolean,
     onAddElement: (DrawElement) -> Unit,
     textMeasurer: TextMeasurer = rememberTextMeasurer(),
@@ -186,7 +190,8 @@ fun DrawingCanvas(
                 onValueChange = { textInput = it },
                 textStyle = TextStyle(
                     color = selectedColor,
-                    fontSize = 16.sp
+                    fontSize = selectedFontSize,
+                    fontStyle = if (isItalics) FontStyle.Italic else FontStyle.Normal
                 ),
                 keyboardOptions = KeyboardOptions(
                     imeAction = ImeAction.Done,
@@ -200,7 +205,8 @@ fun DrawingCanvas(
                                     text = textInput,
                                     position = position,
                                     color = selectedColor,
-                                    fontSize = 16.sp
+                                    fontSize = selectedFontSize,
+                                    italics = isItalics
                                 )
                             )
                         }
@@ -238,7 +244,8 @@ private fun DrawScope.drawElement(element: DrawElement, textMeasurer: TextMeasur
                 topLeft = element.position,
                 style = TextStyle(
                     color = element.color,
-                    fontSize = element.fontSize
+                    fontSize = element.fontSize,
+                    fontStyle = if (element.italics) FontStyle.Italic else FontStyle.Normal
                 )
             )
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/DrawingCanvas.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/DrawingCanvas.kt
@@ -263,12 +263,10 @@ private fun DrawScope.drawShapePreview(
             )
         }
         ShapeType.CIRCLE -> {
-            val center = Offset((start.x + end.x) / 2, (start.y + end.y) / 2)
-            val radius = sqrt((end.x - start.x).pow(2) + (end.y - start.y).pow(2)) / 2
-            drawCircle(
+            drawOval(
                 color = color,
-                center = center,
-                radius = radius,
+                topLeft = Offset(minOf(start.x, end.x), minOf(start.y, end.y)),
+                size = Size(abs(end.x - start.x), abs(end.y - start.y)),
                 style = stroke
             )
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/DrawingModels.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/DrawingModels.kt
@@ -32,6 +32,7 @@ sealed class DrawElement {
         val text: String,
         val position: Offset,
         val color: Color,
-        val fontSize: TextUnit
+        val fontSize: TextUnit,
+        val italics: Boolean
     ) : DrawElement()
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/SnippingToolActionBar.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/SnippingToolActionBar.kt
@@ -37,13 +37,13 @@ fun SnippingToolActionBar(
         ) {
             IconButton(
                 onClick = onUndo,
-                modifier = Modifier.size(32.dp)
+                modifier = Modifier.size(40.dp)
             ) {
                 Icon(Icons.AutoMirrored.Filled.Undo, contentDescription = stringResource(com.oracle.visualize.R.string.undo), tint = MaterialTheme.colorScheme.onPrimaryContainer)
             }
             IconButton(
                 onClick = onRedo,
-                modifier = Modifier.size(32.dp)
+                modifier = Modifier.size(40.dp)
             ) {
                 Icon(Icons.AutoMirrored.Default.Redo, contentDescription = stringResource(com.oracle.visualize.R.string.redo), tint = MaterialTheme.colorScheme.onPrimaryContainer)
             }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/SnippingToolBar.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/SnippingToolBar.kt
@@ -53,9 +53,9 @@ fun SnippingToolbar(
     var showColorPicker by remember { mutableStateOf(false) }
     var showThicknessPicker by remember { mutableStateOf(false) }
     var showShapePicker by remember { mutableStateOf(false) }
-
     val density = LocalDensity.current
     val offsetPx = with(density) { 42.dp.roundToPx() }
+    val iconsize = 42.dp
 
     Box(modifier = modifier) {
         Surface(
@@ -68,7 +68,7 @@ fun SnippingToolbar(
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = onPenClick, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = onPenClick, modifier = Modifier.size(iconsize)) {
                     Icon(
                         painter = painterResource(R.drawable.pen),
                         contentDescription = stringResource(R.string.toolbar_pen),
@@ -76,7 +76,7 @@ fun SnippingToolbar(
                         else MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
-                IconButton(onClick = onEraserClick, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = onEraserClick, modifier = Modifier.size(iconsize)) {
                     Icon(
                         painter = painterResource(R.drawable.eraser),
                         contentDescription = stringResource(R.string.toolbar_eraser),
@@ -85,7 +85,7 @@ fun SnippingToolbar(
                     )
                 }
                 Box {
-                    IconButton(onClick = { showColorPicker = !showColorPicker }, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = { showColorPicker = !showColorPicker }, modifier = Modifier.size(iconsize)) {
                         Box(
                             modifier = Modifier
                                 .size(20.dp)
@@ -107,7 +107,7 @@ fun SnippingToolbar(
                     }
                 }
                 Box {
-                    IconButton(onClick = { showThicknessPicker = !showThicknessPicker }, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = { showThicknessPicker = !showThicknessPicker }, modifier = Modifier.size(iconsize)) {
                         Icon(
                             painter = painterResource(R.drawable.thickness),
                             contentDescription = stringResource(R.string.toolbar_thickness),
@@ -120,7 +120,7 @@ fun SnippingToolbar(
                         }
                     }
                 }
-                IconButton(onClick = onTextClick, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = onTextClick, modifier = Modifier.size(iconsize)) {
                     Icon(
                         Icons.Default.TextFields,
                         contentDescription = stringResource(R.string.toolbar_text),
@@ -129,7 +129,7 @@ fun SnippingToolbar(
                     )
                 }
                 Box {
-                    IconButton(onClick = { showShapePicker = !showShapePicker }, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = { showShapePicker = !showShapePicker }, modifier = Modifier.size(iconsize)) {
                         Icon(
                             painter = painterResource(R.drawable.shapes),
                             contentDescription = stringResource(R.string.toolbar_shape),
@@ -153,7 +153,7 @@ fun SnippingToolbar(
                         showShapePicker = false
                         onCropClick()
                     },
-                    modifier = Modifier.size(32.dp)
+                    modifier = Modifier.size(iconsize)
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.scissors),

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/SnippingToolBar.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/SnippingToolBar.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Crop
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -33,7 +35,9 @@ import com.oracle.visualize.presentation.screens.snippingTool.components.pickers
 import com.oracle.visualize.presentation.screens.snippingTool.components.pickers.ShapePicker
 import com.oracle.visualize.presentation.screens.snippingTool.components.pickers.ThicknessPicker
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.PopupProperties
 import com.oracle.visualize.R
+import com.oracle.visualize.presentation.screens.snippingTool.components.pickers.TextPicker
 
 @Composable
 fun SnippingToolbar(
@@ -41,12 +45,16 @@ fun SnippingToolbar(
     onEraserClick: () -> Unit,
     onColorClick: (DrawModeColors) -> Unit,
     strokeWidth: Float,
+    fontSize: Float,
     onThicknessClick: (Float) -> Unit,
     onTextClick: () -> Unit,
+    onFontSizeChange: (Float) -> Unit,
     onShapeClick: (ShapeType) -> Unit,
     onCropClick: () -> Unit,
     selectedColor: Color,
     selectedTool: DrawingTool?,
+    isItalics: Boolean,
+    italicsToggle: () -> Unit,
     cropMode: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -57,11 +65,23 @@ fun SnippingToolbar(
     val offsetPx = with(density) { 42.dp.roundToPx() }
     val iconsize = 42.dp
 
-    Box(modifier = modifier) {
+    fun openThickness() { showThicknessPicker = !showThicknessPicker; showShapePicker = false }
+    fun openShapes()    { showShapePicker = !showShapePicker; showThicknessPicker = false }
+    fun onTextButtonClick() {
+        showThicknessPicker = false
+        showShapePicker = false
+        onTextClick()
+    }
+
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center
+    ) {
         Surface(
             shape = RoundedCornerShape(50),
             color = MaterialTheme.colorScheme.primaryContainer,
-            tonalElevation = 4.dp
+            tonalElevation = 4.dp,
+            shadowElevation = 4.dp
         ) {
             Row(
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
@@ -84,6 +104,7 @@ fun SnippingToolbar(
                         else MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
+
                 Box {
                     IconButton(onClick = { showColorPicker = !showColorPicker }, modifier = Modifier.size(iconsize)) {
                         Box(
@@ -95,7 +116,12 @@ fun SnippingToolbar(
                         )
                     }
                     if (showColorPicker) {
-                        Popup(alignment = Alignment.BottomCenter, offset = IntOffset(0, -offsetPx)) {
+                        Popup(
+                            alignment = Alignment.BottomCenter,
+                            offset = IntOffset(0, -offsetPx),
+                            onDismissRequest = { showColorPicker = false },
+                            properties = PopupProperties(focusable = true)
+                        ) {
                             ColorPicker(
                                 selectedColor = selectedColor,
                                 onColorChange = { color ->
@@ -106,8 +132,9 @@ fun SnippingToolbar(
                         }
                     }
                 }
+
                 Box {
-                    IconButton(onClick = { showThicknessPicker = !showThicknessPicker }, modifier = Modifier.size(iconsize)) {
+                    IconButton(onClick = { openThickness() }, modifier = Modifier.size(iconsize)) {
                         Icon(
                             painter = painterResource(R.drawable.thickness),
                             contentDescription = stringResource(R.string.toolbar_thickness),
@@ -115,21 +142,43 @@ fun SnippingToolbar(
                         )
                     }
                     if (showThicknessPicker) {
-                        Popup(alignment = Alignment.BottomCenter, offset = IntOffset(0, -offsetPx)) {
+                        Popup(
+                            alignment = Alignment.BottomCenter,
+                            offset = IntOffset(0, -offsetPx),
+                            onDismissRequest = { showThicknessPicker = false },
+                            properties = PopupProperties(focusable = true)
+                        ) {
                             ThicknessPicker(strokeWidth = strokeWidth, onThicknessChange = { onThicknessClick(it) })
                         }
                     }
                 }
-                IconButton(onClick = onTextClick, modifier = Modifier.size(iconsize)) {
-                    Icon(
-                        Icons.Default.TextFields,
-                        contentDescription = stringResource(R.string.toolbar_text),
-                        tint = if (selectedTool == DrawingTool.TEXT && !cropMode) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
+
                 Box {
-                    IconButton(onClick = { showShapePicker = !showShapePicker }, modifier = Modifier.size(iconsize)) {
+                    IconButton(onClick = { onTextButtonClick() }, modifier = Modifier.size(iconsize)) {
+                        Icon(
+                            Icons.Default.TextFields,
+                            contentDescription = stringResource(R.string.toolbar_text),
+                            tint = if (selectedTool == DrawingTool.TEXT && !cropMode) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                    if (selectedTool == DrawingTool.TEXT && !cropMode) {
+                        Popup(
+                            alignment = Alignment.BottomCenter,
+                            offset = IntOffset(0, -offsetPx)
+                        ) {
+                            TextPicker(
+                                isItalics = isItalics,
+                                fontSize = fontSize,
+                                onFontSizeChange = { onFontSizeChange(it) },
+                                onItalicsToggle = { italicsToggle() }
+                            )
+                        }
+                    }
+                }
+
+                Box {
+                    IconButton(onClick = { openShapes() }, modifier = Modifier.size(iconsize)) {
                         Icon(
                             painter = painterResource(R.drawable.shapes),
                             contentDescription = stringResource(R.string.toolbar_shape),
@@ -138,7 +187,12 @@ fun SnippingToolbar(
                         )
                     }
                     if (showShapePicker) {
-                        Popup(alignment = Alignment.BottomCenter, offset = IntOffset(0, -offsetPx)) {
+                        Popup(
+                            alignment = Alignment.BottomCenter,
+                            offset = IntOffset(0, -offsetPx),
+                            onDismissRequest = { showShapePicker = false },
+                            properties = PopupProperties(focusable = true)
+                        ) {
                             ShapePicker(onShapeChange = { shape ->
                                 onShapeClick(shape)
                                 showShapePicker = false
@@ -146,6 +200,7 @@ fun SnippingToolbar(
                         }
                     }
                 }
+
                 IconButton(
                     onClick = {
                         showColorPicker = false
@@ -156,11 +211,12 @@ fun SnippingToolbar(
                     modifier = Modifier.size(iconsize)
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.scissors),
+                        Icons.Filled.Crop,
                         contentDescription = stringResource(R.string.toolbar_crop),
                         tint = if (cropMode) MaterialTheme.colorScheme.primary
                         else MaterialTheme.colorScheme.onPrimaryContainer
                     )
+
                 }
             }
         }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/pickers/TextPicker.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/components/pickers/TextPicker.kt
@@ -1,0 +1,106 @@
+package com.oracle.visualize.presentation.screens.snippingTool.components.pickers
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FormatItalic
+import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import com.oracle.visualize.R
+
+@Composable
+fun TextPicker(
+    isItalics: Boolean,
+    fontSize: Float,
+    onFontSizeChange: (Float) -> Unit,
+    onItalicsToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val surfaceColor = MaterialTheme.colorScheme.primaryContainer
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Surface(
+            shape = RoundedCornerShape(25),
+            color = surfaceColor,
+            tonalElevation = 4.dp
+        ) {
+            Column(
+                modifier = Modifier.padding(vertical = 16.dp, horizontal = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                IconButton(
+                    onClick = {
+                        onItalicsToggle(!isItalics)
+                    },
+                    modifier = Modifier.size(42.dp)
+                ) {
+                    Icon(
+                        Icons.Default.FormatItalic,
+                        contentDescription = stringResource(R.string.toolbar_crop),
+                        tint = if (isItalics) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .height(50.dp)
+                        .width(32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Slider(
+                        value = fontSize,
+                        onValueChange = onFontSizeChange,
+                        valueRange = 10f..50f,
+                        modifier = Modifier
+                            .width(200.dp)
+                            .graphicsLayer { rotationZ = -90f }
+                            .layout { measurable, constraints ->
+                                val placeable = measurable.measure(
+                                    Constraints.fixed(constraints.maxHeight, constraints.maxWidth)
+                                )
+                                layout(placeable.height, placeable.width) {
+                                    placeable.place(-placeable.width / 2 + placeable.height / 2, -placeable.height / 2 + placeable.width / 2)
+                                }
+                            }
+                    )
+                }
+            }
+        }
+
+        Canvas(modifier = Modifier.size(width = 16.dp, height = 16.dp)) {
+            val path = Path().apply {
+                moveTo(0f, 0f)
+                lineTo(size.width, 0f)
+                lineTo(size.width / 2, size.height)
+                close()
+            }
+            drawPath(path, color = surfaceColor)
+        }
+    }
+}


### PR DESCRIPTION
Tweaked the snipping tool with the following changes:
- Separated the snipping tool from the full visualization screen; this allows for discarding when exiting the snipping tool.
- Tweaked the snipping tool toolbar to more closely resemble Material Design 3's floating toolbar.
- Added insets in the snipping tool to prevent android's navigation to tamper with the cropoverlay interaction.
- Removed FABs, switched for icon buttons at the top of the screen to allow for more toolbar space and avoiding covering up the snipping tool.
- Added additional text features; you can now change the text size and toggle italics.