### PR TITLE
Add Snipping Preview Screen

### DIFF
--- a/app/src/main/java/com/oracle/visualize/domain/usecases/comment/CreateCommentUseCase.kt
+++ b/app/src/main/java/com/oracle/visualize/domain/usecases/comment/CreateCommentUseCase.kt
@@ -23,7 +23,7 @@ class CreateCommentUseCase @Inject constructor(
         imageURL: String? = null
     ): AppResult<Comment> {
 
-        if (content.isBlank()) {
+        if (content.isBlank() && imageURL.isNullOrBlank()) {
             return AppResult.Error(AppError.InvalidComment())
         }
 

--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
@@ -148,16 +148,6 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                         )
                     )
                 },
-                onSnipClick = { uri ->
-                    uri?.let { safeUri ->
-                        navController.navigate(
-                            NavRoutes.SnipPreview(
-                                visualizationId = route.visualizationId,
-                                snipUri = safeUri
-                            )
-                        )
-                    }
-                }
             )
         }
 
@@ -257,12 +247,11 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                         )
                     ) {
                         popUpTo(
-                            NavRoutes.SnipPreview(
-                                visualizationId = route.visualizationId,
-                                snipUri = route.snipUri
+                            NavRoutes.FullScreen(
+                                visualizationId = route.visualizationId
                             )
                         ) {
-                            inclusive = true
+                            inclusive = false
                         }
                     }
                 }
@@ -276,7 +265,7 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                 visualizationId = route.visualizationId,
                 onDone = { uri ->
                     navController.navigate(
-                        NavRoutes.Threads(
+                        NavRoutes.SnipPreview(
                             visualizationId = route.visualizationId,
                             snipUri = uri
                         )

--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
@@ -22,6 +22,7 @@ import com.oracle.visualize.presentation.screens.resetPasswordScreen.ResetPasswo
 import com.oracle.visualize.presentation.screens.selectChartScreen.ChartSelectionPage
 import com.oracle.visualize.presentation.screens.shareScreen.ShareAndPostScreen
 import com.oracle.visualize.presentation.screens.signupScreen.SignUpPage
+import com.oracle.visualize.presentation.screens.snipPreviewScreen.SnipPreviewPage
 import com.oracle.visualize.presentation.screens.splashScreen.SplashPage
 import com.oracle.visualize.presentation.screens.threadsScreen.ThreadsPage
 
@@ -131,13 +132,22 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                 modifier            = Modifier.fillMaxSize(),
                 startInSnippingMode = route.startInSnippingMode,
                 onBackClick         = { navController.popBackStack() },
-                onThreadsClick      = { uri ->
+                onThreadsClick = {
                     navController.navigate(
                         NavRoutes.Threads(
-                            visualizationId = route.visualizationId,
-                            snipUri         = uri
+                            visualizationId = route.visualizationId
                         )
                     )
+                },
+                onSnipClick = { uri ->
+                    uri?.let { safeUri ->
+                        navController.navigate(
+                            NavRoutes.SnipPreview(
+                                visualizationId = route.visualizationId,
+                                snipUri = safeUri
+                            )
+                        )
+                    }
                 }
             )
         }
@@ -218,6 +228,30 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
             ResetPasswordPage(
                 modifier           = Modifier.fillMaxSize(),
                 onBackToLoginClick = { navController.popBackStack() }
+            )
+        }
+
+        composable<NavRoutes.SnipPreview> { backStackEntry ->
+            val route = backStackEntry.toRoute<NavRoutes.SnipPreview>()
+
+            SnipPreviewPage(
+                visualizationId = route.visualizationId,
+                snipUri = route.snipUri,
+                modifier = Modifier.fillMaxSize(),
+                onBackClick = {
+                    navController.popBackStack()
+                },
+                onShareCompleted = {
+                    navController.navigate(
+                        NavRoutes.Threads(
+                            visualizationId = route.visualizationId
+                        )
+                    ) {
+                        popUpTo(NavRoutes.FullScreen(route.visualizationId)) {
+                            inclusive = true
+                        }
+                    }
+                }
             )
         }
     }

--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/AppNavHost.kt
@@ -247,7 +247,12 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                             visualizationId = route.visualizationId
                         )
                     ) {
-                        popUpTo(NavRoutes.FullScreen(route.visualizationId)) {
+                        popUpTo(
+                            NavRoutes.SnipPreview(
+                                visualizationId = route.visualizationId,
+                                snipUri = route.snipUri
+                            )
+                        ) {
                             inclusive = true
                         }
                     }

--- a/app/src/main/java/com/oracle/visualize/presentation/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/navigation/NavRoutes.kt
@@ -47,4 +47,6 @@ sealed interface NavRoutes {
     data class CreateEditTeam(val teamId: String? = null) : NavRoutes
     @Serializable
     object ResetPassword : NavRoutes
+    @Serializable
+    data class SnipPreview(val visualizationId: String, val snipUri: String): NavRoutes
 }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
@@ -64,6 +64,7 @@ fun FullVisualizationPage(
     modifier: Modifier = Modifier,
     viewModel: FullVisualizationViewModel = hiltViewModel(),
     onBackClick: () -> Unit,
+    onSnipClick: (String?) -> Unit,
     onThreadsClick: (String?) -> Unit = {},
     startInSnippingMode: Boolean = false
 ) {
@@ -115,7 +116,7 @@ fun FullVisualizationPage(
                 val uri = File(context.cacheDir, "snip_${System.currentTimeMillis()}.png").also { file ->
                     file.outputStream().use { result.compress(Bitmap.CompressFormat.PNG, 100, it) }
                 }.toURI().toString()
-                onThreadsClick(uri)
+                onSnipClick(uri)
             },
             onCancel = { snippingBitmap = null }
         )

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/fullVisualizationScreen/FullVisualizationView.kt
@@ -64,7 +64,6 @@ fun FullVisualizationPage(
     modifier: Modifier = Modifier,
     viewModel: FullVisualizationViewModel = hiltViewModel(),
     onBackClick: () -> Unit,
-    onSnipClick: (String?) -> Unit,
     onThreadsClick: (String?) -> Unit = {},
     startInSnippingMode: Boolean = false,
     onSnippingClick: (String?) -> Unit

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snipPreviewScreen/SnipPreviewUIState.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snipPreviewScreen/SnipPreviewUIState.kt
@@ -1,0 +1,9 @@
+package com.oracle.visualize.presentation.screens.snipPreviewScreen
+
+data class SnipPreviewUIState(
+    val caption: String = "",
+    val showConfirmDialog: Boolean = false,
+    val isSharing: Boolean = false,
+    val errorMessage: Int? = null,
+    val shareCompleted: Boolean = false
+)

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snipPreviewScreen/SnipPreviewView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snipPreviewScreen/SnipPreviewView.kt
@@ -1,0 +1,179 @@
+package com.oracle.visualize.presentation.screens.snipPreviewScreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.oracle.visualize.R
+import com.oracle.visualize.presentation.screens.threadsScreen.components.ThreadsTopBar
+
+@Composable
+fun SnipPreviewPage(
+    visualizationId: String,
+    snipUri: String,
+    modifier: Modifier = Modifier,
+    viewModel: SnipPreviewViewModel = hiltViewModel(),
+    onBackClick: () -> Unit,
+    onShareCompleted: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState.shareCompleted) {
+        if (uiState.shareCompleted) {
+            viewModel.consumeShareCompleted()
+            onShareCompleted()
+        }
+    }
+
+    if (uiState.showConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                if (!uiState.isSharing) {
+                    viewModel.dismissConfirmDialog()
+                }
+            },
+            containerColor = MaterialTheme.colorScheme.surface,
+            titleContentColor = MaterialTheme.colorScheme.onSurface,
+            textContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            title = { Text(stringResource(R.string.dialog_confirm_title)) },
+            text = { Text(stringResource(R.string.dialog_confirm_message)) },
+            confirmButton = {
+                TextButton(
+                    enabled = !uiState.isSharing,
+                    onClick = {
+                        viewModel.shareSnipAsThread(
+                            visualizationId = visualizationId,
+                            snipUri = snipUri
+                        )
+                    }
+                ) {
+                    Text(
+                        text = if (uiState.isSharing) stringResource(R.string.dialog_confirm_yes_atl) else stringResource(R.string.dialog_confirm_yes),
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    enabled = !uiState.isSharing,
+                    onClick = { viewModel.dismissConfirmDialog() }
+                ) {
+                    Text(
+                        stringResource(R.string.dialog_confirm_no),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0),
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { viewModel.showConfirmDialog() },
+                containerColor = MaterialTheme.colorScheme.secondary
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Send,
+                    contentDescription = stringResource(R.string.dialog_confirm_yes),
+                    tint = MaterialTheme.colorScheme.onSecondary
+                )
+            }
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(paddingValues)
+        ) {
+            ThreadsTopBar(
+                title = stringResource(R.string.preview),
+                onBackClick = onBackClick
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.caption),
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+
+                Text(
+                    text = stringResource(R.string.share_insights),
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                OutlinedTextField(
+                    value = uiState.caption,
+                    onValueChange = viewModel::onCaptionChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(120.dp),
+                    enabled = !uiState.isSharing,
+                    placeholder = {
+                        Text(stringResource(R.string.add_desc))
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    maxLines = 5
+                )
+
+                Spacer(modifier = Modifier.height(28.dp))
+
+                Text(
+                    text = stringResource(R.string.preview_edited_vis),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                AsyncImage(
+                    model = snipUri,
+                    contentDescription = stringResource(R.string.edit_preview),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentScale = ContentScale.Fit
+                )
+
+                if (uiState.isSharing) {
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(28.dp),
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
+                Spacer(modifier = Modifier.height(80.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snipPreviewScreen/SnipPreviewViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snipPreviewScreen/SnipPreviewViewModel.kt
@@ -1,0 +1,100 @@
+package com.oracle.visualize.presentation.screens.snipPreviewScreen
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.oracle.visualize.R
+import com.oracle.visualize.domain.exceptions.AppResult
+import com.oracle.visualize.domain.repositories.AuthRepository
+import com.oracle.visualize.domain.usecases.comment.CreateCommentUseCase
+import com.oracle.visualize.domain.usecases.comment.UploadSnipUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SnipPreviewViewModel @Inject constructor(
+    private val uploadSnipUseCase: UploadSnipUseCase,
+    private val createCommentUseCase: CreateCommentUseCase,
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SnipPreviewUIState())
+    val uiState: StateFlow<SnipPreviewUIState> = _uiState.asStateFlow()
+
+    private val currentUserID: String = authRepository.getCurrentUserID() ?: ""
+
+    fun onCaptionChange(value: String) {
+        _uiState.update { it.copy(caption = value) }
+    }
+
+    fun showConfirmDialog() {
+        _uiState.update { it.copy(showConfirmDialog = true) }
+    }
+
+    fun dismissConfirmDialog() {
+        _uiState.update { it.copy(showConfirmDialog = false) }
+    }
+
+    fun consumeShareCompleted() {
+        _uiState.update { it.copy(shareCompleted = false) }
+    }
+
+    fun shareSnipAsThread(
+        visualizationId: String,
+        snipUri: String
+    ) {
+        if (_uiState.value.isSharing) return
+
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isSharing = true,
+                    showConfirmDialog = false,
+                    errorMessage = null
+                )
+            }
+
+            val imageUrl = when (val uploadResult = uploadSnipUseCase(currentUserID, snipUri)) {
+                is AppResult.Success -> uploadResult.data
+                is AppResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isSharing = false,
+                            errorMessage = R.string.error_upload_snip
+                        )
+                    }
+                    return@launch
+                }
+            }
+
+            when (createCommentUseCase(
+                visualizationId = visualizationId,
+                authorID = currentUserID,
+                content = _uiState.value.caption,
+                imageURL = imageUrl
+            )) {
+                is AppResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isSharing = false,
+                            shareCompleted = true
+                        )
+                    }
+                }
+
+                is AppResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isSharing = false,
+                            errorMessage = R.string.error_create_comment
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
@@ -72,26 +72,6 @@ fun SnippingToolView(
     modifier: Modifier = Modifier,
     viewModel: SnippingToolViewModel = hiltViewModel()
 ) {
-
-
-
-    // TODO: Right now, the navigation bar appearing and reappearing crooks the crop. Fix this later.
-
-// DisposableEffect(Unit) {
-//     val window = (view.context as Activity).window
-//     val controller = WindowInsetsControllerCompat(window, view)
-//
-//     window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-//     controller.hide(WindowInsetsCompat.Type.systemBars())
-//     controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-//
-//     onDispose {
-//         window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-//         controller.show(WindowInsetsCompat.Type.systemBars())
-//     }
-// }
-
-
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val graphicsLayer = rememberGraphicsLayer()
     val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
@@ -117,44 +117,6 @@ fun SnippingToolView(
         viewModel.loadVisualization(visualizationId)
     }
 
-    if (uiState.showConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { viewModel.toggleConfirmDialog() },
-            containerColor = MaterialTheme.colorScheme.surface,
-            titleContentColor = MaterialTheme.colorScheme.onSurface,
-            textContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            title = { Text(stringResource(R.string.dialog_confirm_title)) },
-            text = { Text(stringResource(R.string.dialog_confirm_message)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    viewModel.toggleConfirmDialog()
-                    coroutineScope.launch {
-                        val bitmap = viewModel.confirmCrop(graphicsLayer.toImageBitmap().asAndroidBitmap())
-                        val uri = withContext(Dispatchers.IO) {
-                            File(context.cacheDir, "snip_${System.currentTimeMillis()}.png").also { file ->
-                                file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
-                            }.toURI().toString()
-                        }
-                        onDone(uri)
-                    }
-                }) {
-                    Text(
-                        stringResource(R.string.dialog_confirm_yes),
-                        color = MaterialTheme.colorScheme.secondary
-                    )
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { viewModel.toggleConfirmDialog() }) {
-                    Text(
-                        stringResource(R.string.dialog_confirm_no),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-        )
-    }
-
     if (uiState.showCancelDialog) {
         AlertDialog(
             onDismissRequest = { viewModel.toggleCancelDialog() },
@@ -236,7 +198,23 @@ fun SnippingToolView(
                                         Icon(Icons.Default.Close, contentDescription = stringResource(R.string.cancel))
                                     }
                                     FilledIconButton(
-                                        onClick = { viewModel.toggleConfirmDialog() },
+                                        onClick = {
+                                            coroutineScope.launch {
+                                                val bitmap = viewModel.confirmCrop(
+                                                    graphicsLayer.toImageBitmap().asAndroidBitmap()
+                                                )
+
+                                                val uri = withContext(Dispatchers.IO) {
+                                                    File(context.cacheDir, "snip_${System.currentTimeMillis()}.png").also { file ->
+                                                        file.outputStream().use {
+                                                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+                                                        }
+                                                    }.toURI().toString()
+                                                }
+
+                                                onDone(uri)
+                                            }
+                                        },
                                         colors = IconButtonDefaults.filledIconButtonColors(
                                             containerColor = MaterialTheme.colorScheme.secondary,
                                             contentColor = MaterialTheme.colorScheme.onSecondary

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/snippingTool/SnippingToolView.kt
@@ -88,38 +88,6 @@ fun SnippingToolView(
         offset += panChange
     }
 
-    if (uiState.showConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { viewModel.toggleConfirmDialog() },
-            containerColor = MaterialTheme.colorScheme.surface,
-            titleContentColor = MaterialTheme.colorScheme.onSurface,
-            textContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            title = { Text(stringResource(R.string.dialog_confirm_title)) },
-            text = { Text(stringResource(R.string.dialog_confirm_message)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    viewModel.toggleConfirmDialog()
-                    coroutineScope.launch {
-                        onDone(viewModel.confirmCrop(graphicsLayer.toImageBitmap().asAndroidBitmap()))
-                    }
-                }) {
-                    Text(
-                        stringResource(R.string.dialog_confirm_yes),
-                        color = MaterialTheme.colorScheme.secondary
-                    )
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { viewModel.toggleConfirmDialog() }) {
-                    Text(
-                        stringResource(R.string.dialog_confirm_no),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-        )
-    }
-
     if (uiState.showCancelDialog) {
         AlertDialog(
             onDismissRequest = { viewModel.toggleCancelDialog() },
@@ -257,7 +225,15 @@ fun SnippingToolView(
                 Icon(Icons.Default.Close, contentDescription = stringResource(R.string.fab_cancel), tint = MaterialTheme.colorScheme.onSecondary)
             }
             FloatingActionButton(
-                onClick = { viewModel.toggleConfirmDialog() },
+                onClick = {
+                    coroutineScope.launch {
+                        onDone(
+                            viewModel.confirmCrop(
+                                graphicsLayer.toImageBitmap().asAndroidBitmap()
+                            )
+                        )
+                    }
+                },
                 containerColor = MaterialTheme.colorScheme.secondary
             ) {
                 Icon(Icons.AutoMirrored.Filled.Send, contentDescription = stringResource(R.string.fab_confirm), tint = MaterialTheme.colorScheme.onSecondary)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,7 @@
     <string name="fab_confirm">Confirm</string>
     <string name="fab_cancel">Cancel</string>
     <string name="dialog_confirm_title">Share as New Thread</string>
-    <string name="dialog_confirm_message">This edited visualization will be shared as a new thread. To reply to an existing thread, go to the Threads section.</string>
+    <string name="dialog_confirm_message">This edited visualization will be shared as a new thread.</string>
     <string name="dialog_confirm_yes">Share</string>
     <string name="dialog_confirm_yes_atl">Sharing...</string>
     <string name="dialog_confirm_no">Cancel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="dialog_confirm_title">Share as New Thread</string>
     <string name="dialog_confirm_message">This edited visualization will be shared as a new thread. To reply to an existing thread, go to the Threads section.</string>
     <string name="dialog_confirm_yes">Share</string>
+    <string name="dialog_confirm_yes_atl">Sharing...</string>
     <string name="dialog_confirm_no">Cancel</string>
     <string name="dialog_cancel_title">Discard Changes</string>
     <string name="dialog_cancel_message">If you cancel, your changes will not be saved.</string>
@@ -343,5 +344,14 @@
     <string name="chart_theme_sunset">Sunset</string>
     <string name="chart_theme_harvest">Harvest</string>
     <string name="chart_theme_petal">Petal</string>
+
+    // Snipping Tool Preview Page
+    <string name="caption">Caption</string>
+    <string name="share_insights">Share insights about this edited visualization.</string>
+    <string name="add_desc">Add an optional description...</string>
+    <string name="edit_preview">Edited visualization preview</string>
+    <string name="preview_edited_vis">Preview of the edited visualization</string>
+
+
 
 </resources>


### PR DESCRIPTION
Implementation of the Snipping Tool Preview Screen, which allows users to have a more visual preview before uploading the snip to Threads.

New Files: 

- SnipPreviewUIState.kt
- SnipPreviewViewModel.kt
- SnipPreviewView.kt

This files are the creation of the new screen.

Changes to existing Files:

- AppNavHost.kt
- FullVisualizationView.kt
- NavRoutes.kt
- SnippingToolView.kt
- strings.xml

These files were changed to:

- Add navigation to the new screen
- Remove older snip to thread logic
- implementation of strings to strings.xml