### PR TITLE
Fix. Fullscreen legend display on portrait mode

### DIFF
--- a/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentFullScreen.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentFullScreen.kt
@@ -2,6 +2,7 @@ package com.oracle.visualize.presentation.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
@@ -130,6 +132,7 @@ fun ChartRenderFullScreen(
                         else -> {
                             Row(
                                 modifier = Modifier.fillMaxWidth()
+                                    .horizontalScroll(rememberScrollState())
                                     .background(color = MaterialTheme.colorScheme.onPrimary),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.Center

--- a/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentGeneral.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentGeneral.kt
@@ -101,12 +101,16 @@ fun ChartRenderGeneral(
 
             is PieChartModel -> RenderPieChart(chart = chart, chartColorTheme = chartColorTheme, enableTooltips = enableTooltips)
 
-            is DonutChart -> RenderDonutChart(chart = chart, chartColorTheme = chartColorTheme, enableTooltips = enableTooltips)
+            is DonutChart -> RenderDonutChart(
+                chart = chart, chartColorTheme = chartColorTheme, feedCardLabel = feedCardLabels,
+                enableTooltips = enableTooltips
+            )
 
             is AreaChart -> RenderAreaChart(
                 chart = chart, showAxisLabels = showAxisLabels, chartColorTheme = chartColorTheme,
                 enableTooltips = enableTooltips, enableZoomAndPan = enableZoomAndPan
             )
+
             is TileChart -> RenderTileChart(
                 modifier = Modifier.fillMaxSize(),
                 chart = chart,

--- a/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentGeneral.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/ChartComponentGeneral.kt
@@ -57,13 +57,6 @@ fun ChartRenderGeneral(
     enableZoomAndPan: Boolean = true,
     feedCardLabels: Boolean = false
 ) {
-    val scrollState = rememberScrollState()
-    var chartWidth: Dp
-    var barCount: Int
-    var scrollable: Boolean
-    var boxModifier: Modifier
-    var chartModifier: Modifier
-
     val topPadding = if (feedCardLabels) 8.dp else 18.dp
     val bottomPadding = if (feedCardLabels) 8.dp else 8.dp
     val sidePadding = if (feedCardLabels) 6.dp else 6.dp

--- a/app/src/main/java/com/oracle/visualize/presentation/components/charts/DonutChartComponent.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/components/charts/DonutChartComponent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.oracle.visualize.domain.models.DonutChart
 import com.oracle.visualize.presentation.components.generateChartColors
 import com.oracle.visualize.ui.theme.ChartPalette
@@ -35,7 +36,13 @@ import kotlin.math.roundToInt
  */
 @OptIn(ExperimentalKoalaPlotApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun RenderDonutChart(modifier: Modifier = Modifier, chart: DonutChart, chartColorTheme: ChartPalette, enableTooltips: Boolean) {
+fun RenderDonutChart(
+    modifier: Modifier = Modifier,
+    chart: DonutChart,
+    chartColorTheme: ChartPalette,
+    feedCardLabel: Boolean,
+    enableTooltips: Boolean
+) {
     val coroutineScope = rememberCoroutineScope()
     val categories = chart.fieldNames
     val values = chart.data
@@ -59,15 +66,17 @@ fun RenderDonutChart(modifier: Modifier = Modifier, chart: DonutChart, chartColo
             holeSize = 0.6f,
             holeContent = {
                 Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Column {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
                             text = "Total",
                             style = MaterialTheme.typography.titleMedium,
+                            fontSize = if (feedCardLabel) 13.sp else 18.sp,
                             color = Color.DarkGray
                         )
                         Text(
                             text = (values.sum().roundToInt() / 1.0f).toString(),
                             style = MaterialTheme.typography.titleMedium,
+                            fontSize = if (feedCardLabel) 9.sp else 14.sp,
                             color = Color.DarkGray
                         )
                     }

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/components/ChartCard.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/selectChartScreen/components/ChartCard.kt
@@ -93,7 +93,9 @@ fun ChartCard(
                 ChartRenderGeneral(
                     chart = chart,
                     chartColorTheme = chartColorTheme,
-                    feedCardLabels = true
+                    feedCardLabels = true,
+                    enableTooltips  = false,
+                    enableZoomAndPan = false
                 )
             }
         }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">10.48.9.139</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary

- Applied horizontal scroll on the displayed legends on the fullscreen chart visualization, giving a cleaner look to the view, without modifying the actual chart height, depending on the amount of legends.
- Extra: Modified some parameters on the ChartCard from Select Chart Screen to hide tooltips and disable zooming and panning, as configured on Feed Cards.

If any issues, please let me know.