### PR TITLE
refactor: changed team's name from ITC-6to to VisTeam

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,7 +209,7 @@
     <string name="version_declaration">Version</string>
     <string name="chart_theme_title">Chart theme</string>
     <string name="about_title">About</string>
-    <string name="developer">Developed by ITC-6to</string>
+    <string name="developer">Developed by VisTeam</string>
     <string name="terms_of_service">Terms of Service</string>
     <string name="licenses">Licenses and open source libraries</string>
     <string name="preview">Preview</string>


### PR DESCRIPTION
## What was done?

Changed the developer team name from ITC-6to to VisTeam as was accorded between both teams.