### PR TITLE
fix: feed state now persists when changing tabs.

### DIFF
--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -47,6 +48,7 @@ fun FeedPage(
 ) {
     val uiState        by feedViewModel.uiState.collectAsStateWithLifecycle<FeedUiState>()
     val scrollBehavior  = TopAppBarDefaults.pinnedScrollBehavior()
+    val listState = rememberLazyListState()
 
     // Auto-reload when resuming from ShareWithTeammates
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -117,6 +119,7 @@ fun FeedPage(
 
                 is FeedUiState.Success -> {
                     LazyColumn(
+                        state = listState,
                         verticalArrangement = Arrangement.spacedBy(16.dp),
                         modifier            = Modifier.fillMaxSize().padding(horizontal = 20.dp)
                     ) {

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/feedScreen/FeedViewModel.kt
@@ -1,6 +1,7 @@
 package com.oracle.visualize.presentation.screens.feedScreen
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.oracle.visualize.R
 import com.oracle.visualize.data.datasources.local.FeedCacheManager
@@ -37,12 +38,17 @@ class FeedViewModel @Inject constructor(
     private val deleteVisualizationForEveryoneUseCase: DeleteVisualizationForEveryoneUseCase,
     private val hideVisualizationForMeUseCase: HideVisualizationForMeUseCase,
     private val getUserChartThemeUseCase: GetUserChartThemeUseCase,
-    private val feedCacheManager: FeedCacheManager
+    private val feedCacheManager: FeedCacheManager,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<FeedUiState>(FeedUiState.Loading)
     val uiState: StateFlow<FeedUiState> = _uiState.asStateFlow()
+    private val FILTER_KEY = "selected_filter"
 
+    private val savedFilter: VisualizationFilter
+        get() = savedStateHandle.get<String>(FILTER_KEY)?.let { enumValueOf<VisualizationFilter>(it) }
+            ?: VisualizationFilter.ALL
     private var allFeedItems: List<FeedItem> = emptyList()
     private var currentUserID: String = ""
     private var currentUserType: UserType = UserType.CONSUMER
@@ -143,6 +149,7 @@ class FeedViewModel @Inject constructor(
     }
 
     fun onFilterChange(filter: VisualizationFilter) {
+        savedStateHandle[FILTER_KEY] = filter.name
         val currentState = _uiState.value
         if (currentState is FeedUiState.Success && currentState.selectedFilter == filter) return
         _uiState.value = when (currentState) {
@@ -258,7 +265,7 @@ class FeedViewModel @Inject constructor(
 
     private fun applyLocalFilterAndSearch() {
         val currentState = _uiState.value
-        val filter      = if (currentState is FeedUiState.Success) currentState.selectedFilter else VisualizationFilter.ALL
+        val filter      = if (currentState is FeedUiState.Success) currentState.selectedFilter else savedFilter
         val search      = if (currentState is FeedUiState.Success) currentState.searchText else ""
         val isSearching = if (currentState is FeedUiState.Success) currentState.isSearching else false
 

--- a/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
+++ b/app/src/main/java/com/oracle/visualize/presentation/screens/mainScreen/MainView.kt
@@ -56,7 +56,7 @@ fun MainScreen(
                     currentDestination = currentDestination,
                     onItemSelected = { destination ->
                         navController.navigate(destination) {
-                            popUpTo(navController.graph.startDestinationId) {
+                            popUpTo<NavRoutes.Feed> {
                                 saveState = true
                             }
                             launchSingleTop = true


### PR DESCRIPTION
When interacting with the feed, going to another tab and coming back to the feed, its state was reseted to the top of the All Feed. Now the Feed's state will persist when navigating trough tabs.